### PR TITLE
Fixes from Singapore PBA Lecture

### DIFF
--- a/text/header.tex
+++ b/text/header.tex
@@ -41,7 +41,7 @@ We assume the state-Merklization function $\mathcal{M}_\sigma$ is capable of tra
 
 All blocks have an associated public key to identify the author of the block. We identify this as an index into the current validator set $\kappa$. We denote the Bandersnatch key of the author as $\mathbf{H}_a$ though note that this is merely an equivalence, and is not serialized as part of the header.
 \begin{equation}
-  \mathbf{H}_k \in \N_V \,,\quad \mathbf{H}_a \equiv \kappa[\mathbf{H}_k]
+  \mathbf{H}_k \in \N_\mathsf{V} \,,\quad \mathbf{H}_a \equiv \kappa[\mathbf{H}_k]
 \end{equation}
 
 \subsection{The Epoch and Winning Tickets Markers}\label{sec:header_epochmarker}

--- a/text/judgements.tex
+++ b/text/judgements.tex
@@ -49,7 +49,7 @@ We define $\mathbf{J}$ as the sequence of judgements introduced in the block's e
 
 Formally:
 \begin{align}
-  \mathbf{J} &\in \seq{\tup{\H, \seq{\H_B}_{2:3}, \N}} \\
+  \mathbf{J} &\in \seq{\tup{\H, \N}} \\
   \mathbf{J} &= \sq{\tup{r, \sum_{\tup{v, i, s} \in \mathbf{v}}\!\!\!\! v}\ \middle\mid\ \tup{r, \mathbf{v}} \orderedin \mathbf{E}_J} \\
   &\forall \tup{r, t} \in \mathbf{J} : t \in \{0, \floor{\nicefrac{1}{3}\mathsf{V}}, \floor{\nicefrac{2}{3}\mathsf{V}} + 1 \}
 \end{align}

--- a/text/judgements.tex
+++ b/text/judgements.tex
@@ -17,7 +17,7 @@ The judgements state includes three items, an allow-set ($\psi_\mathbf{a}$), a b
   \psi \equiv \tup{\psi_\mathbf{a}, \psi_\mathbf{b}, \psi_\mathbf{p}, \psi_\mathbf{k}}
 \end{equation}
 
-`\subsection{Extrinsic}
+\subsection{Extrinsic}
 
 The judgements extrinsic, $\mathbf{E}_J$ may contain one or more judgements as a compilation of signatures coming from exactly two-thirds plus one of either the active validator set (\ie the Ed25519 keys of $\kappa$) or the previous epoch's validator set (\ie the keys of $\psi_\mathbf{k}$):
 \begin{equation}

--- a/text/recent_history.tex
+++ b/text/recent_history.tex
@@ -5,7 +5,7 @@ We retain in state information on the most recent $\mathsf{H}$ blocks. This is u
   \beta \in \lseq\ltuple \isa{h}{\H}\ts\isa{\mathbf{b}}{\seq{\H?}}\ts\isa{s}{\H}\ts\isa{\mathbf{p}}{\lseq\H\rseq_{:\mathsf{C}}} \rtuple\rseq_{:\mathsf{H}}
 \end{equation}
 
-For each recent block, we retain its header hash, its state root, its accumulation-result \textsc{mmr} and the hash of each work-report made into it which is no more than the total number of cores, $\mathcal{C} = 341$.
+For each recent block, we retain its header hash, its state root, its accumulation-result \textsc{mmr} and the hash of each work-report made into it which is no more than the total number of cores, $\mathsf{C} = 341$.
 
 During the accumulation stage, a value with the partial transition of this state is provided which contains the update for the newly-known roots of the parent block:
 \begin{equation}
@@ -29,4 +29,3 @@ The final state transition is then:
 Thus, we extend the recent history with the new block's header hash, its accumulation-result Merkle tree root and the set of work-reports made into it. Note that the accumulation-result tree root $r$ is derived from $\mathbf{C}$ (defined in section \ref{sec:accumulation}) using the basic binary Merklization function $\mathcal{M}_B$ (defined in appendix \ref{sec:merklization}) and appending it using the \textsc{mmr} append function $\mathcal{A}$ (defined in appendix \ref{sec:mmr}) to form a Merkle mountain range.
 
 The state-trie root is as being the zero hash, $\H^0$ which while inaccurate at the end state of the block $\beta'$, it is nevertheless safe since $\bm{\beta'}$ is not utilized except to define the next block's $\bm{\beta^\dagger}$, which contains a corrected value for this.
-

--- a/text/reporting_assurance.tex
+++ b/text/reporting_assurance.tex
@@ -156,13 +156,13 @@ We define the permute function $P$, the rotation function $R$ and finally the gu
 \begin{align}
   P(e, t) &\equiv R\left(\mathcal{F}\left(\left[\ffrac{\mathsf{V}\cdot i}{\mathsf{C}} \,\middle\mid\, i \orderedin \N_\mathsf{V}\right], e\right), \ffrac{t \bmod \mathsf{E}}{\mathsf{R}}\right)\!\!\!\!\!\! \\[3pt]
   R(\mathbf{c}, n) &\equiv [(x + n) \bmod \mathsf{C} \mid x \orderedin \mathbf{c}]\\
-  \forall c \in \N_C : \mathbf{G} &\equiv [ \kappa'_i \mid i \orderedin \N_V, P(\eta_2', \tau')_i = c ]
+  \forall c \in \N_C : \mathbf{G} &\equiv [ \kappa'_i \mid i \orderedin \N_\mathsf{V}, P(\eta_2', \tau')_i = c ]
 \end{align}
 
 We also define $\mathbf{G}^*$, which is equivalent to the value $\mathbf{G}$ as it would have been under the previous rotation:
 \begin{align}
   \label{eq:priorassignments}
-  \forall c \in \N_C : \mathbf{G}^* &\equiv [ \mathbf{k}_i \mid i \orderedin \N_V, P(e, \tau' - \mathsf{R})_i = c ]\\
+  \forall c \in \N_C : \mathbf{G}^* &\equiv [ \mathbf{k}_i \mid i \orderedin \N_\mathsf{V}, P(e, \tau' - \mathsf{R})_i = c ]\\
   \where e &= \begin{cases}
     (\eta'_2, \kappa) &\when \displaystyle\ffrac{\tau' - \mathsf{R}}{\mathsf{E}} = \ffrac{\tau'}{\mathsf{E}}\\
     (\eta'_3, \lambda) &\otherwise

--- a/text/safrole.tex
+++ b/text/safrole.tex
@@ -97,7 +97,7 @@ With a new epoch under regular conditions, validator keys get rotated and the ep
   \begin{aligned}
     \!\!\!\!\!\!\!\!\!\!\!\!(\gamma'_\mathbf{k}, \kappa', \lambda', \gamma'_z) &\equiv \begin{cases} (\iota, N(\gamma_\mathbf{k}), N(\kappa), z) \!\!\!\!&\when e' > e \wedge \mathbf{H}_j = [] \\ (\gamma_\mathbf{k}, N(\kappa), N(\lambda), \gamma_z) \!\!\!\!&\otherwise \end{cases}\!\!\!\!\!\!\!\! \\
     \where z &= \mathcal{O}([k_b \mid k \orderedin \gamma'_\mathbf{k}]) \\
-    \also N(\mathbf{k}) &\equiv \sq{\begin{rcases} [0, 0, \dots] &\when k_e \in \psi'_\mathbf{p} \\ k &\otherwise \end{rcases} \,\middle\mid\, k \orderedin \mathbf{k}}
+    \also N(\mathbf{k}) &\equiv \sq{\begin{rcases} [0, 0, \dots] &\when k_b \in \psi'_\mathbf{p} \\ k &\otherwise \end{rcases} \,\middle\mid\, k \orderedin \mathbf{k}}
   \end{aligned}
 \end{equation}
 

--- a/text/safrole.tex
+++ b/text/safrole.tex
@@ -211,7 +211,7 @@ The epoch and winning-tickets markers are information placed in the header in or
 As mentioned earlier, the header's epoch marker $\mathbf{H}_e$ is either empty or, if the block is the first in a new epoch, then a tuple of the epoch randomness and a sequence of Bandersnatch keys defining the Bandersnatch validator keys ($k_b$) beginning in the next epoch. Formally:
 \begin{align}\label{eq:epochmarker}
   \mathbf{H}_e &\equiv \begin{cases}
-    ( \eta'_1, [ k_e \mid k \orderedin \gamma'_\mathbf{k} ] )\qquad\qquad &\when e' > e \\
+    ( \eta'_1, [ k_b \mid k \orderedin \gamma'_\mathbf{k} ] )\qquad\qquad &\when e' > e \\
     \none & \otherwise
   \end{cases}
 \end{align}


### PR DESCRIPTION
- Noted in the lecture that N sub V should use san-serif V. Replaced other such instances assuming the same.
- Noted in the lecture that `k_e` is incorrect, and should be `k_b` referencing the bandersnatch keys
- Number of cores should use san-serif `C`
- Removes a hanging apostrophe in "Jugements > Extrinsics"
- Removes `\seq{\H_B}_{2:3}` from the definition of J, the sequence of judgements introduced in the block’s extrinsic. (As noted in class)