### PR TITLE
Zero sized values are embedded in the trie

### DIFF
--- a/text/merklization.tex
+++ b/text/merklization.tex
@@ -74,7 +74,7 @@ Formally, we define the encoding functions $B$ and $L$:
   L&\colon\left\{\begin{aligned}
     (\H, \Y) &\to \mathbb{B}_{512}\\
     (k, v) &\mapsto \begin{cases}
-      [1, 0] \frown \text{bits}(\se_1(|v|))_{\dots6} \frown \text{bits}(k)_{\dots248} \frown \text{bits}(v) \frown [0, 0, \dots] &\when 0 < |v| \le 32\\
+      [1, 0] \frown \text{bits}(\se_1(|v|))_{\dots6} \frown \text{bits}(k)_{\dots248} \frown \text{bits}(v) \frown [0, 0, \dots] &\when |v| \le 32\\
       [1, 1, 0, 0, 0, 0, 0, 0] \frown \text{bits}(k)_{\dots248} \frown \text{bits}(\mathcal{H}(v)) &\otherwise
     \end{cases}
   \end{aligned}\right.


### PR DESCRIPTION
0-size values should be embedded for simplicity. This is compatible with the rest of the spec.