### PR TITLE
Various fixes for Elves security

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,17 +8,6 @@ https://graypaper.com/
 
 ## Remaining near-term
 
-### ELVES
-- [x] Don't immediately alter kappa mid-epoch as it affects off-chain judgements.
-- [x] Instead, apply the blacklist to guarantor sig verification directly.
-- [x] Include the core in the WR.
-- [x] Deposit the WR's signatures in with the judgement.
-- [x] Require at >= 1 negative judgements to be included with a positive verdict, and place signer in punish keys.
-- [x] Serialization of judgement stuff
-- [x] Should always be possible to submit more guarantee signatures of a known-bad report to place them in the punish set.
-  - [x] Only from lambda and kappa?
-- [x] Use posterior kappa for everything except judgements.
-
 ### Finesse
 - [ ] Make all subscript names capitalized
 - [ ] Ensure all definitions are referenced
@@ -210,5 +199,15 @@ https://graypaper.com/
   - [x] payload hash - easy
   - [x] gas prioritization - just from WP?
   - [x] Consider introducing a host-call for reading manifest data rather than always passing it in.
+### ELVES
+- [x] Don't immediately alter kappa mid-epoch as it affects off-chain judgements.
+- [x] Instead, apply the blacklist to guarantor sig verification directly.
+- [x] Include the core in the WR.
+- [x] Deposit the WR's signatures in with the judgement.
+- [x] Require at >= 1 negative judgements to be included with a positive verdict, and place signer in punish keys.
+- [x] Serialization of judgement stuff
+- [x] Should always be possible to submit more guarantee signatures of a known-bad report to place them in the punish set.
+  - [x] Only from lambda and kappa?
+- [x] Use posterior kappa for everything except judgements.
 
 % A set of independent, sequential, asynchronously interacting 32-octet state machines each of whose transitions lasts around 2 seconds of webassembly computation if a predetermined and fixed program and whose transition arguments are 5 MB. While well-suited to the verification of substrate blockchains, it is otherwise quite limiting.

--- a/README.md
+++ b/README.md
@@ -11,10 +11,10 @@ https://graypaper.com/
 ### ELVES
 - [x] Don't immediately alter kappa mid-epoch as it affects off-chain judgements.
 - [x] Instead, apply the blacklist to guarantor sig verification directly.
+- [x] Include the core in the WR.
 - [ ] Deposit the WR's signatures in with the judgement.
-- [ ] Include the core in the WR.
 - [ ] Require at >= 1 negative judgements to be included with a positive verdict, and place signer in punish keys.
-- [ ] Use posterior kappa for everything except judgements.
+- [x] Use posterior kappa for everything except judgements.
 
 ### Finesse
 - [ ] Make all subscript names capitalized

--- a/README.md
+++ b/README.md
@@ -12,8 +12,11 @@ https://graypaper.com/
 - [x] Don't immediately alter kappa mid-epoch as it affects off-chain judgements.
 - [x] Instead, apply the blacklist to guarantor sig verification directly.
 - [x] Include the core in the WR.
-- [ ] Deposit the WR's signatures in with the judgement.
-- [ ] Require at >= 1 negative judgements to be included with a positive verdict, and place signer in punish keys.
+- [x] Deposit the WR's signatures in with the judgement.
+- [x] Require at >= 1 negative judgements to be included with a positive verdict, and place signer in punish keys.
+- [x] Serialization of judgement stuff
+- [x] Should always be possible to submit more guarantee signatures of a known-bad report to place them in the punish set.
+  - [x] Only from lambda and kappa?
 - [x] Use posterior kappa for everything except judgements.
 
 ### Finesse

--- a/README.md
+++ b/README.md
@@ -8,6 +8,14 @@ https://graypaper.com/
 
 ## Remaining near-term
 
+### ELVES
+- [x] Don't immediately alter kappa mid-epoch as it affects off-chain judgements.
+- [x] Instead, apply the blacklist to guarantor sig verification directly.
+- [ ] Deposit the WR's signatures in with the judgement.
+- [ ] Include the core in the WR.
+- [ ] Require at >= 1 negative judgements to be included with a positive verdict, and place signer in punish keys.
+- [ ] Use posterior kappa for everything except judgements.
+
 ### Finesse
 - [ ] Make all subscript names capitalized
 - [ ] Ensure all definitions are referenced

--- a/preamble.tex
+++ b/preamble.tex
@@ -45,6 +45,7 @@
 \providecommand{\tightlist}{\setlength{\itemsep}{0pt}\setlength{\parskip}{0pt}}
 
 \makeatletter
+\catcode`\¬=11
 \newcommand{\superimpose}[2]{{%
   \ooalign{%
     \hfil$\m@th#1\@firstoftwo#2$\hfil\cr
@@ -136,6 +137,9 @@
 \newcommand*{\fnfrac}[2]{\left\lfloor\nicefrac{#1}{#2}\right\rfloor}
 \newcommand*{\ffrac}[2]{\left\lfloor\frac{#1}{#2}\right\rfloor}
 \newcommand*{\transpose}{{}^\text{T}}
+
+% GP terms
+
 
 \title[JAM: Join-Accumulate Machine \\ {\smaller \textbf{Draft 0.2.3-pre \today}}]{Join-Accumulate Machine: A Semi-Coherent Scalable Trustless VM \\ {\smaller Draft 0.2.3-pre \today}}
 \author{

--- a/text/authorization.tex
+++ b/text/authorization.tex
@@ -22,8 +22,8 @@ Note: The portion of state $\varphi$ may be altered only through an exogenous ca
 
 The state transition of a block involves placing a new authorization into the pool from the queue:
 \begin{align}
-  \forall c \in \N_\mathsf{C} : \alpha'[c] &\equiv {\overleftarrow{F(c) \doubleplus \varphi'[c] [ \mathbf{H}_t ]^{\circlearrowleft}}}^{\mathsf{O}} \\
-  F(c) &\equiv \begin{cases} \alpha[c] \seqminusl \{g_a\} & \when \exists g \in E_G : g_c = c \\ \alpha[c] & \otherwise \end{cases}\!\!\!\!\!
+  &\forall c \in \N_\mathsf{C} : \alpha'[c] \equiv {\overleftarrow{F(c) \doubleplus \varphi'[c] [ \mathbf{H}_t ]^{\circlearrowleft}}}^{\mathsf{O}} \\
+  &F(c) \equiv \begin{cases} \alpha[c] \seqminusl \{(g_w)_a\} &\when \exists g \in \mathbf{E}_G : (g_w)_c = c \\ \alpha[c] & \otherwise \end{cases}
 \end{align}
 
-Since $\alpha'$ is dependent on $\varphi'$, practically speaking, this step must be computed after accumulation, the stage in which $\varphi'$ is defined.
+Since $\alpha'$ is dependent on $\varphi'$, practically speaking, this step must be computed after accumulation, the stage in which $\varphi'$ is defined. Note that we utilize the guarantees extrinsic $\mathbf{E}_G$ to remove the oldest authorizer which has been used to justify a guaranteed work-package in the current block. This is further defined in equation \ref{eq:guaranteesextrinsic}.

--- a/text/definitions.tex
+++ b/text/definitions.tex
@@ -70,7 +70,7 @@
 \subsection{Functions}
 
 \begin{description}
-  \item[$\Gamma$] Item to result function. %	Γ
+%  \item[$\Gamma$] Unused. %	Γ
 %  \item[$\Delta$] Unused. %	Δ
 %  \item[$\Theta$] Unused. %	Θ
 %  \item[$\Pi$] Unused. %	Π

--- a/text/definitions.tex
+++ b/text/definitions.tex
@@ -78,7 +78,7 @@
   \item[$\Xi$] The work result computation function. See equation \ref{eq:workresultfunction}. %	Ξ
   \item[$\Upsilon$] The general state transition function. See equations \ref{eq:statetransition}, \ref{eq:transitionfunctioncomposition}. %	ϒ
 %  \item[$\Sigma$] Unused. %	Σ
-%  \item[$\Phi$] Unused. %	Φ
+  \item[$\Phi$] The key-nullifier function. See equation \ref{eq:blacklistfilter}. %	Φ
   \item[$\Psi$] The whole-program \textsc{pvm} machine state-transition function. See equation \ref{sec:virtualmachine}. %	Ψ
   \begin{description}
     \item[$\Psi_1$] The single-step (\textsc{pvm}) machine state-transition function. See appendix \ref{sec:virtualmachine}. %	Ψ

--- a/text/header.tex
+++ b/text/header.tex
@@ -41,7 +41,7 @@ We assume the state-Merklization function $\mathcal{M}_\sigma$ is capable of tra
 
 All blocks have an associated public key to identify the author of the block. We identify this as an index into the current validator set $\kappa$. We denote the Bandersnatch key of the author as $\mathbf{H}_a$ though note that this is merely an equivalence, and is not serialized as part of the header.
 \begin{equation}
-  \mathbf{H}_k \in \N_\mathsf{V} \,,\quad \mathbf{H}_a \equiv \kappa[\mathbf{H}_k]
+  \mathbf{H}_k \in \N_\mathsf{V} \,,\quad \mathbf{H}_a \equiv \kappa'[\mathbf{H}_k]
 \end{equation}
 
 \subsection{The Epoch and Winning Tickets Markers}\label{sec:header_epochmarker}

--- a/text/judgements.tex
+++ b/text/judgements.tex
@@ -12,54 +12,77 @@ As mentioned, recording reports found to have a high confidence of invalidity is
 
 \subsection{State}
 
-The judgements state includes three items, an allow-set ($\psi_\mathbf{a}$), a ban-set ($\psi_\mathbf{b}$) and a punish-set ($\psi_\mathbf{p}$). The allow-set contains the hashes of all work-reports which were disputed and judged to be accurate. The ban-set contains the hashes of all work-reports which were disputed and whose accuracy could not be confidently confirmed. The punish-set is a set of Ed25519 keys representing validators which were found to have guaranteed a report which was confidently found to be invalid.
+The judgements state includes three items, an allow-set ($\psi_\mathbf{a}$), a ban-set ($\psi_\mathbf{b}$), a corrupt-set ($\psi_\mathbf{c}$) and a punish-set ($\psi_\mathbf{p}$). The allow-set, ban-set and corrupt-set contains the hashes of all work-reports which were respectively judged to be correct, uncertain or incorrect. The punish-set is a set of Ed25519 keys representing validators which were found to have misjudged a work-report.
 \begin{equation}
-  \psi \equiv \tup{\psi_\mathbf{a}, \psi_\mathbf{b}, \psi_\mathbf{p}}
+  \psi \equiv \tup{\psi_\mathbf{a}, \psi_\mathbf{b}, \psi_\mathbf{c}, \psi_\mathbf{p}}
 \end{equation}
 
 \subsection{Extrinsic}
 
-The judgements extrinsic, $\mathbf{E}_J$ may contain one or more judgements as a compilation of signatures coming from exactly two-thirds plus one of either the active validator set or the previous epoch's validator set, \ie the Ed25519 keys of $\kappa$ or $\lambda$:
-\begin{equation}
-  \mathbf{E}_J \in \seq{\tup{\H, \ffrac{\tau}{\mathsf{E}} - \N_2, \seq{\tup{\{\top, \bot\}, \N_{\mathsf{V}}, \mathbb{E}}}_{\floor{\nicefrac{2}{3}\mathsf{V}} + 1}}}\!\!\!
-\end{equation}
-
-All signatures must be valid in terms of one of the two allowed validator key-sets, identified by the second term which must be either the epoch index of the prior state or one less. Formally:
+The judgements extrinsic, $\mathbf{E}_J$ may contain one or more judgements $\mathbf{j}$ as a compilation of signatures coming from exactly two-thirds plus one of either the active validator set or the previous epoch's validator set, \ie the Ed25519 keys of $\kappa$ or $\lambda$. Additionally, it may contain signatures proving the misbehavior of one or more validators, either by guaranteeing a work-report found to be invalid in the sequence of culprits $\mathbf{c}$, or by signing a judgement vote (\ie audit result) found to be contradiction to a work-report's validity in the sequence of faults $\mathbf{f}$. Formally:
 \begin{equation}
   \begin{aligned}
-    \forall (r, a, \mathbf{v}) \in \mathbf{E}_J ,\, &\forall (v, i, s) \in \mathbf{v} : s \in \sig{\mathbf{k}[i]_e}{\mathsf{X}_v \concat r}\\
-    \where \mathsf{X}_\top &= \text{{\small \texttt{\$jam\_valid}}} \\
-    \text{and } \mathsf{X}_\bot &= \text{{\small \texttt{\$jam\_invalid}}} \\
-    \mathbf{k} &= \begin{cases}
-      \kappa &\when a = \displaystyle \ffrac{\tau}{\mathsf{E}}\\
-      \lambda &\otherwise\\
-    \end{cases}
+    \mathbf{E}_J &\equiv (\mathbf{j}, \mathbf{c}, \mathbf{f}) \\
+    \where \mathbf{j} &\in \seq{\tup{\H, \ffrac{\tau}{\mathsf{E}} - \N_2, \seq{\tup{\{\top, \bot\}, \N_{\mathsf{V}}, \mathbb{E}}}_{\floor{\nicefrac{2}{3}\mathsf{V}} + 1}}}\\
+    \also \mathbf{c} &\in \seq{\H, \H_E, \mathbf{E}} \,,\quad
+    \mathbf{f} \in \seq{\H, \H_E, \mathbf{E}}
   \end{aligned}
 \end{equation}
 
-Judgements must be ordered by report hash and there may be no duplicate report hashes within the extrinsic, nor amongst any past reported hashes. Formally:
+Each judgement in $\mathbf{j}$ implies at least two items with the same report hash in the sequence of culprits $\mathbf{c}$ and at least one item with the same report hash in the sequence of faults $\mathbf{f}$. Formally:
+\begin{equation}
+  \forall (r, \dots) \in \mathbf{j} : |\{(r, \dots) \in \mathbf{c}\}| \ge 2 \wedge \exists (r, \dots) \in \mathbf{f}
+\end{equation}
+
+All judgement signatures must be valid in terms of one of the two allowed validator key-sets, identified by the second term which must be either the epoch index of the prior state or one less. Formally:
 \begin{align}
-  \mathbf{E}_J = \orderuniqby{r}{\tup{r, \mathbf{v}} \in \mathbf{E}_J} \\
-  \{r \mid \tup{r, \mathbf{v}}\} \disjoint \psi_\mathbf{a} \cup \psi_\mathbf{b}
+  &\begin{aligned}
+    &\forall (r, a, \mathbf{v}) \in \mathbf{j}, \forall (v, i, s) \in \mathbf{v} : s \in \sig{\mathbf{k}[i]_e}{\mathsf{X}_v \concat r}\\
+    &\quad\where \mathbf{k} = \begin{cases}
+      \kappa &\when a = \displaystyle \ffrac{\tau}{\mathsf{E}}\\
+      \lambda &\otherwise\\
+    \end{cases}
+  \end{aligned}\\
+  &\mathsf{X}_\top \equiv \text{{\small \texttt{\$jam\_valid}}}\,,\ \mathsf{X}_\bot \equiv \text{{\small \texttt{\$jam\_invalid}}}
+\end{align}
+
+Culprit and fault signatures must be similarly valid and reference work-reports with judgements and may not report targets which are already in the punish-set:
+\begin{align}
+  &\begin{aligned}
+      &\forall (r, k, s) \in \mathbf{c} :\\
+      &\quad r \in \varphi'_\mathbf{b} \cup \varphi'_\mathbf{c} \wedge
+      k \in (\lambda \cup \kappa) \setminus \varphi_\mathbf{p} \wedge
+      s \in \sig{k}{\mathsf{X}_G \frown r}
+  \end{aligned}\\
+  &\begin{aligned}
+      &\forall (r, k, s) \in \mathbf{f} :\\
+      &\quad r \in \varphi'_\mathbf{a} \cup \varphi'_\mathbf{c} \wedge
+      k \in (\lambda \cup \kappa) \setminus \varphi_\mathbf{p} \wedge
+      s \in \sig{k}{\mathsf{X}_{r \in \varphi'_\mathbf{c}} \concat r}\\
+  \end{aligned}
+\end{align}
+
+Judgements $\mathbf{j}$ must be ordered by report hash, culprit signatures $\mathbf{c}$ and $\mathbf{f}$ ordered by culprit identity. There may be no duplicate report hashes within the extrinsic, nor amongst any past reported hashes. Formally:
+\begin{align}
+  &\mathbf{j} = \orderuniqby{r}{\tup{r, a, \mathbf{v}} \in \mathbf{j}}\\
+  &\{r \mid \tup{r, a, \mathbf{v}} \in \mathbf{j}\} \disjoint \psi_\mathbf{a} \cup \psi_\mathbf{b}
 \end{align}
 
 The votes of all judgements must be ordered by validator index and there may be no duplicate such indices. Formally:
 \begin{equation}
-  \forall (r, \mathbf{v}) \in \mathbf{E}_J : \mathbf{v} = \orderuniqby{i}{\tup{v, i, s} \in \mathbf{v}}
+  \forall (r, a, \mathbf{v}) \in \mathbf{j} : \mathbf{v} = \orderuniqby{i}{\tup{v, i, s} \in \mathbf{v}}
 \end{equation}
 
-We define $\mathbf{J}$ as the sequence of judgements introduced in the block's extrinsic (and ordered respectively), with the sequence of signatures substituted with the sum of votes over the signatures. We require this total to be exactly zero, two-thirds-plus-one or one-third-plus-one of the validator set indicating, respectively, that we are confident of the report's validity, confident of its invalidity, or lacking confidence in either. This requirement may seem somewhat arbitrary, but these happen to be the decision thresholds for our three possible actions and are acceptable since the security assumptions include the requirement that at least two-thirds-plus-one validators are live (\cite{cryptoeprint:2024/961} discusses the security implications in depth).
-
-Formally:
+We define $\mathbf{J}$ as the sequence of judgements introduced in the block's extrinsic (and ordered respectively), with the sequence of signatures substituted with the sum of votes over the signatures. We require this total to be exactly zero, two-thirds-plus-one or one-third-plus-one of the validator set indicating, respectively, that we are confident of the report's validity, confident of its invalidity, or lacking confidence in either. This requirement may seem somewhat arbitrary, but these happen to be the decision thresholds for our three possible actions and are acceptable since the security assumptions include the requirement that at least two-thirds-plus-one validators are live (\cite{cryptoeprint:2024/961} discusses the security implications in depth). Formally:
 \begin{align}
   \mathbf{J} &\in \seq{\tup{\H, \N}} \\
-  \mathbf{J} &= \sq{\tup{r, \sum_{\tup{v, i, s} \in \mathbf{v}}\!\!\!\! v}\ \middle\mid\ \tup{r, \mathbf{v}} \orderedin \mathbf{E}_J} \\
+  \mathbf{J} &= \sq{\tup{r, \sum_{\tup{v, i, s} \in \mathbf{v}}\!\!\!\! v}\ \middle\mid\ \tup{r, a, \mathbf{v}} \orderedin \mathbf{j}} \\
   &\forall \tup{r, t} \in \mathbf{J} : t \in \{0, \floor{\nicefrac{1}{3}\mathsf{V}}, \floor{\nicefrac{2}{3}\mathsf{V}} + 1 \}
 \end{align}
 
 Note that $t$ is the threshold of judgements that the report is \emph{valid}, calculated by summing Boolean values in their implicit equivalence to binary digits of the set $\N_2$.
 
-We clear any work-reports judged to be non-valid from their core:
+We clear any work-reports which we judged as uncertain or invalid from their core:
 \begin{equation}
   \forall c \in \N_\mathsf{C} : \rho^\dagger[c] = \begin{cases}
     \none &\when \{ (\rho[c]_r, t) \in \mathbf{J}, t < \floor{\nicefrac{2}{3}\mathsf{V}} \} \\
@@ -67,14 +90,13 @@ We clear any work-reports judged to be non-valid from their core:
   \end{cases}
 \end{equation}
 
-The allow-set assimilates the hashes of any reports we judge to be valid. The ban-set assimilates any other judged report-hashes. Finally, the punish-set accumulates the guarantor keys of any report judged to be invalid:
+The allow-set, ban-set and corrupt-set assimilates the hashes of any reports we judge to be valid, uncertain or invalid. Finally, the punish-set accumulates the keys of any validators who have found to have misjudged a report. Formally:
 \begin{align}
   \psi'_\mathbf{a} &\equiv \psi_\mathbf{a} \cup \{r \mid \tup{r, \floor{\nicefrac{2}{3}\mathsf{V}} + 1} \in \mathbf{J} \} \\
-  \psi'_\mathbf{b} &\equiv \psi_\mathbf{b} \cup \{r \mid \tup{r, t} \in \mathbf{J}, t \ne \floor{\nicefrac{2}{3}\mathsf{V}} + 1 \} \\
-  \psi'_\mathbf{p} &\equiv \psi_\mathbf{p} \cup \{ \rho[c]_g \mid (\rho[c]_r, 0) \in \mathbf{J} \}
+  \psi'_\mathbf{b} &\equiv \psi_\mathbf{b} \cup \{r \mid \tup{r, \floor{\nicefrac{1}{3}\mathsf{V}}} \in \mathbf{J} \} \\
+  \psi'_\mathbf{c} &\equiv \psi_\mathbf{c} \cup \{r \mid \tup{r, 0} \in \mathbf{J} \} \\
+  \psi'_\mathbf{p} &\equiv \psi_\mathbf{p} \cup \{ k \mid (r, k, s) \in \mathbf{c} \cup \mathbf{f} \}
 \end{align}
-
-Note that the augmented punish-set is utilized when determining $\kappa'$ to nullify any validator keys which appear in the punish-list.
 
 \subsection{Header}\label{sec:judgementmarker}
 

--- a/text/recent_history.tex
+++ b/text/recent_history.tex
@@ -14,7 +14,7 @@ During the accumulation stage, a value with the partial transition of this state
 
 The final state transition is then:
 \begin{equation}
-\begin{aligned}
+  \begin{aligned}
     \beta' &\equiv {\overleftarrow{\beta^\dagger \doubleplus \ltup\;
     \begin{aligned}
       &\is{\mathbf{p}}{[((g_w)_s)_p \mid g \orderedin \mathbf{E}_G]}\;\ts\\
@@ -23,9 +23,9 @@ The final state transition is then:
     \;\rtup}}^\mathsf{H} \\
     \where \mathbf{b} &= \mathcal{A}(\text{last}(\sq{\sq{}} \concat \sq{x_\mathbf{b} \mid x \orderedin \beta}), r)\\
     \also r &= \mathcal{M}_B(\orderby{x}{\se(x) \mid x \in \mathbf{C}}, \mathcal{H}_K)
-\end{aligned}
+  \end{aligned}
 \end{equation}
 
-Thus, we extend the recent history with the new block's header hash, its accumulation-result Merkle tree root and the set of work-reports made into it. Note that the accumulation-result tree root $r$ is derived from $\mathbf{C}$ (defined in section \ref{sec:accumulation}) using the basic binary Merklization function $\mathcal{M}_B$ (defined in appendix \ref{sec:merklization}) and appending it using the \textsc{mmr} append function $\mathcal{A}$ (defined in appendix \ref{sec:mmr}) to form a Merkle mountain range.
+Thus, we extend the recent history with the new block's header hash, its accumulation-result Merkle tree root and the set of work-reports made into it (for which we use the guarantees extrinsic, $\mathbf{E}_G$). Note that the accumulation-result tree root $r$ is derived from $\mathbf{C}$ (defined in section \ref{sec:accumulation}) using the basic binary Merklization function $\mathcal{M}_B$ (defined in appendix \ref{sec:merklization}) and appending it using the \textsc{mmr} append function $\mathcal{A}$ (defined in appendix \ref{sec:mmr}) to form a Merkle mountain range.
 
 The state-trie root is as being the zero hash, $\H^0$ which while inaccurate at the end state of the block $\beta'$, it is nevertheless safe since $\bm{\beta'}$ is not utilized except to define the next block's $\bm{\beta^\dagger}$, which contains a corrected value for this.

--- a/text/reporting_assurance.tex
+++ b/text/reporting_assurance.tex
@@ -24,15 +24,13 @@ As usual, intermediate and posterior values ($\rho^\dagger$, $\rho^\ddagger$, $\
 A work-report, of the set $\mathbb{W}$, is defined as a tuple of authorizer hash $a$ and output $\mathbf{o}$, the refinement context $x$, the package specification $s$ and the results of the evaluation of each of the items in the package $\mathbf{r}$, which is always at least one item and may be no more than $\mathsf{I}$ items. Formally:
 \begin{equation}\label{eq:workreport}
   \mathbb{W} \equiv \tuple{
-%    \begin{aligned}
-      \isa{a}{\H}\ts
-      \isa{\mathbf{o}}{\Y}\ts
-      \isa{x}{\mathbb{X}}\ts
-      % TODO: ^^^ Rename to c
-      \isa{s}{\mathbb{S}}\ts
-      \isa{\mathbf{r}}{\seq{\mathbb{L}}_{1:\mathsf{I}}}
-%    \end{aligned}
-  }\!\!\!\!\!
+    \isa{a}{\H}\ts
+    \isa{c}{\N_C}\ts
+    \isa{\mathbf{o}}{\Y}\ts
+    \isa{x}{\mathbb{X}}\ts
+    \isa{s}{\mathbb{S}}\ts
+    \isa{\mathbf{r}}{\seq{\mathbb{L}}_{1:\mathsf{I}}}
+  }
 \end{equation}
 
 % TODO: places where w \in \mathbb{W} : w_o should be replaced with w_\mathbb{o} and w_r with w_\mathbb{r}
@@ -110,8 +108,8 @@ The assurances must all be anchored on the parent and ordered by validator index
 
 The signature must be one whose public key is that of the validator assuring and whose message is the serialization of the parent hash $\mathbf{H}_p$ and the aforementioned bitstring:
 \begin{align}
-  &\forall a \in \mathbf{E}_A : a_s \in \sig{\kappa[a_v]_e}{\mathsf{X}_A\frown \mathcal{H}(\mathbf{H}_p, a_f)} \\
-  &\mathsf{X}_A = \token{\$jam\_available}
+  &\forall a \in \mathbf{E}_A : a_s \in \sig{\kappa'[a_v]_e}{\mathsf{X}_A\frown \mathcal{H}(\mathbf{H}_p, a_f)} \\
+  &\mathsf{X}_A \equiv \token{\$jam\_available}
 \end{align}
 
 A bit may only be set if the corresponding core has a report pending availability on it:
@@ -156,14 +154,14 @@ We define the permute function $P$, the rotation function $R$ and finally the gu
 \begin{align}
   P(e, t) &\equiv R\left(\mathcal{F}\left(\left[\ffrac{\mathsf{V}\cdot i}{\mathsf{C}} \,\middle\mid\, i \orderedin \N_\mathsf{V}\right], e\right), \ffrac{t \bmod \mathsf{E}}{\mathsf{R}}\right)\!\!\!\!\!\! \\[3pt]
   R(\mathbf{c}, n) &\equiv [(x + n) \bmod \mathsf{C} \mid x \orderedin \mathbf{c}]\\
-  \forall c \in \N_C : \mathbf{G} &\equiv [ \Phi(\kappa')_i \mid i \orderedin \N_\mathsf{V}, P(\eta_2', \tau')_i = c ]
+  \!\!\forall c \in \N_C : \mathbf{G}_c &\equiv [ \Phi(\kappa')_i \mid i \orderedin \N_\mathsf{V}, P(\eta_2', \tau')_i = c ]
 \end{align}
 
 We also define $\mathbf{G}^*$, which is equivalent to the value $\mathbf{G}$ as it would have been under the previous rotation:
 \begin{equation}
   \label{eq:priorassignments}
   \begin{aligned}
-    \forall c \in \N_C : \mathbf{G}^* &\equiv [ \Phi(\mathbf{k})_i \mid i \orderedin \N_\mathsf{V}, P(e, \tau' - \mathsf{R})_i = c ]\\
+    \forall c \in \N_C : \mathbf{G}_c^* &\equiv [ \Phi(\mathbf{k})_i \mid i \orderedin \N_\mathsf{V}, P(e, \tau' - \mathsf{R})_i = c ]\\
     \where (e, \mathbf{k}) &= \begin{cases}
       (\eta'_2, \kappa') &\when \displaystyle\ffrac{\tau' - \mathsf{R}}{\mathsf{E}} = \ffrac{\tau'}{\mathsf{E}}\\
       (\eta'_3, \lambda') &\otherwise
@@ -187,9 +185,9 @@ We also define $\mathbf{G}^*$, which is equivalent to the value $\mathbf{G}$ as 
 \subsection{Work Report Guarantees}\label{sec:workreportguarantees}
 
 We begin by defining the guarantees extrinsic, $\mathbf{E}_G$, a series of \emph{guarantees}, at most one for each core, each of which is a tuple of a core index, \emph{work-report}, a credential $a$ and its corresponding timeslot $t$. Formally:
-\begin{align}
+\begin{align}\label{eq:guaranteesextrinsic}
   \mathbf{E}_G &\in \seq{\tuple{
-    c \in \N_\mathsf{C},\, w \in \mathbb{W},\, t \in \N_T,\, a \in \seq{\mathbb{E}?}_3
+    w \in \mathbb{W},\, t \in \N_T,\, a \in \seq{\mathbb{E}?}_3
   }}_{:\mathsf{C}} \\
   \forall g &\in \mathbf{E}_G : |\{x \in g_a : x \ne \none\}| \ge 2
 \end{align}
@@ -198,36 +196,40 @@ The credential is a sequence of three tuples of a signature. Credentials may onl
 
 The core index of each guarantee must be unique and in ascending order:
 \begin{align}
-  \mathbf{E}_G = \orderby{i_c}{i \in \mathbf{E}_G}
+  \mathbf{E}_G = \orderby{(g_w)_c}{g \in \mathbf{E}_G}
 \end{align}
 
 The signature must be one whose public key is that of the validator identified in the credential, and whose message is the serialization of the core index and the work-report. The signing validators must be assigned to the core in question in either this block $\mathbf{G}$ if the timeslot for the guarantee is in the same rotation as this block's timeslot, or in the most recent previous set of assignments, $\mathbf{G}^*$:
 \begin{align}\label{eq:guarantorsig}
-    \forall g \in \mathbf{E}_G, \forall i &\in \N_3: \left\{\,\begin{aligned}
-      &g_a[i] \in \sig{\mathbf{k}[g_c]_i}{\mathsf{X}_G\frown\mathcal{H}(g_c, g_r)}\mathbf{?}\\
-      &\mathbf{R} \ni \mathbf{k}[g_c]_i \Leftrightarrow g_a[i] \ne \none\\
+  \begin{aligned}
+    \forall g &\in \mathbf{E}_G,\\
+    \forall i &\in \N_3
+  \end{aligned}
+    : &\left\{\,\begin{aligned}
+      &g_a[i] \in \sig{\mathbf{k}[(g_w)_c]_i}{\mathsf{X}_G\frown\mathcal{H}(\se(g_w))}\mathbf{?}\\
+      &\mathbf{R} \ni \mathbf{k}[(g_w)_c]_i \Leftrightarrow g_a[i] \ne \none\\
       &\where \mathbf{k} = \begin{cases}
         \mathbf{G} \!\!\!\!&\when \displaystyle \ffrac{\tau'}{\mathsf{R}} = \ffrac{g_t}{\mathsf{R}} \\
         \mathbf{G}^* \!\!\!\!&\otherwise
       \end{cases}
     \end{aligned}\right.\!\!\\
-    \mathsf{X}_G &= \token{\$jam\_guarantee}
+    \mathsf{X}_G \equiv &\token{\$jam\_guarantee}
 \end{align}
 
 We note that the Ed25519 key of each validator whose signature is in a credential is placed in the \emph{reporters} set $\mathbf{R}$. This is utilized by the validator activity statistics bookkeeping system section \ref{sec:bookkeeping}.
-
-No reports may be placed on cores with a report pending availability on it unless it has timed out. In the latter case, $\mathsf{U} = 5$ slots must have elapsed after the report was made. A report is invalid if the authorizer hash is not present in the authorizer pool of the core on which the work is reported. Formally:
-\begin{equation}\label{eq:reportcoresareunusedortimedout}
-  \forall g \in \mathbf{E}_G :\left\{\;\begin{aligned}
-    &\rho^\ddagger[g_c] = \none \vee \mathbf{H}_t \ge \rho^\ddagger[g_c]_t + \mathsf{U}\ , \\
-    &g_a \in \alpha[g_c]
-  \end{aligned}\right.
-\end{equation}
 
 We denote $\mathbf{w}$ to be the set of work-reports in the present extrinsic $\mathbf{E}$:
 \begin{align}
   \text{let}\ \mathbf{w} = \{ g_w \mid g \in \mathbf{E}_G \}
 \end{align}
+
+No reports may be placed on cores with a report pending availability on it unless it has timed out. In the latter case, $\mathsf{U} = 5$ slots must have elapsed after the report was made. A report is valid only if the authorizer hash is present in the authorizer pool of the core on which the work is reported. Formally:
+\begin{equation}\label{eq:reportcoresareunusedortimedout}
+  \forall w \in \mathbf{w} :\left\{\;\begin{aligned}
+    &\rho^\ddagger[w_c] = \none \vee \mathbf{H}_t \ge \rho^\ddagger[w_c]_t + \mathsf{U}\ , \\
+    &w_a \in \alpha[w_c]
+  \end{aligned}\right.
+\end{equation}
 
 We specify the maximum total accumulation gas requirement a work-report may imply as $\mathsf{G}_A$, and we require the sum of all services' minimum gas requirements to be no greater than this:
 \begin{align}

--- a/text/reporting_assurance.tex
+++ b/text/reporting_assurance.tex
@@ -156,15 +156,15 @@ We define the permute function $P$, the rotation function $R$ and finally the gu
 \begin{align}
   P(e, t) &\equiv R\left(\mathcal{F}\left(\left[\ffrac{\mathsf{V}\cdot i}{\mathsf{C}} \,\middle\mid\, i \orderedin \N_\mathsf{V}\right], e\right), \ffrac{t \bmod \mathsf{E}}{\mathsf{R}}\right)\!\!\!\!\!\! \\[3pt]
   R(\mathbf{c}, n) &\equiv [(x + n) \bmod \mathsf{C} \mid x \orderedin \mathbf{c}]\\
-  \forall c \in \N_C : \mathbf{G} &\equiv [ \kappa'_i \mid i \orderedin \N_\mathsf{V}, P(\eta_2', \tau')_i = c ]
+  \forall c \in \N_C : \mathbf{G} &\equiv [ \Phi(\kappa')_i \mid i \orderedin \N_\mathsf{V}, P(\eta_2', \tau')_i = c ]
 \end{align}
 
 We also define $\mathbf{G}^*$, which is equivalent to the value $\mathbf{G}$ as it would have been under the previous rotation:
 \begin{equation}
   \label{eq:priorassignments}
   \begin{aligned}
-    \forall c \in \N_C : \mathbf{G}^* &\equiv [ \mathbf{k}_i \mid i \orderedin \N_\mathsf{V}, P(e, \tau' - \mathsf{R})_i = c ]\\
-    \where e &= \begin{cases}
+    \forall c \in \N_C : \mathbf{G}^* &\equiv [ \Phi(\mathbf{k})_i \mid i \orderedin \N_\mathsf{V}, P(e, \tau' - \mathsf{R})_i = c ]\\
+    \where (e, \mathbf{k}) &= \begin{cases}
       (\eta'_2, \kappa') &\when \displaystyle\ffrac{\tau' - \mathsf{R}}{\mathsf{E}} = \ffrac{\tau'}{\mathsf{E}}\\
       (\eta'_3, \lambda') &\otherwise
     \end{cases}
@@ -194,7 +194,7 @@ We begin by defining the guarantees extrinsic, $\mathbf{E}_G$, a series of \emph
   \forall g &\in \mathbf{E}_G : |\{x \in g_a : x \ne \none\}| \ge 2
 \end{align}
 
-The credential is itself a sequence of three tuples of a signature and a validator index $\mathbb{E}$. Credentials may only have one missing signature.
+The credential is a sequence of three tuples of a signature. Credentials may only have one missing signature.
 
 The core index of each guarantee must be unique and in ascending order:
 \begin{align}
@@ -207,10 +207,10 @@ The signature must be one whose public key is that of the validator identified i
       &g_a[i] \in \sig{\mathbf{k}[g_c]_i}{\mathsf{X}_G\frown\mathcal{H}(g_c, g_r)}\mathbf{?}\\
       &\mathbf{R} \ni \mathbf{k}[g_c]_i \Leftrightarrow g_a[i] \ne \none\\
       &\where \mathbf{k} = \begin{cases}
-        \mathbf{G} \!\!\!\!&\when \ffrac{\tau'}{\mathsf{R}} = \ffrac{g_t}{\mathsf{R}} \\
+        \mathbf{G} \!\!\!\!&\when \displaystyle \ffrac{\tau'}{\mathsf{R}} = \ffrac{g_t}{\mathsf{R}} \\
         \mathbf{G}^* \!\!\!\!&\otherwise
       \end{cases}
-    \end{aligned}\right.\\
+    \end{aligned}\right.\!\!\\
     \mathsf{X}_G &= \token{\$jam\_guarantee}
 \end{align}
 

--- a/text/safrole.tex
+++ b/text/safrole.tex
@@ -93,15 +93,18 @@ The set of validator keys itself is equivalent to the set of 336-octet sequences
 \end{align}
 
 With a new epoch under regular conditions, validator keys get rotated and the epoch's Bandersnatch key root is updated into $\gamma'_z$:
-\begin{equation}
-  \begin{aligned}
-    \!\!\!\!\!\!\!\!\!\!\!\!(\gamma'_\mathbf{k}, \kappa', \lambda', \gamma'_z) &\equiv \begin{cases} (\iota, N(\gamma_\mathbf{k}), N(\kappa), z) \!\!\!\!&\when e' > e \wedge \mathbf{H}_j = [] \\ (\gamma_\mathbf{k}, N(\kappa), N(\lambda), \gamma_z) \!\!\!\!&\otherwise \end{cases}\!\!\!\!\!\!\!\! \\
-    \where z &= \mathcal{O}([k_b \mid k \orderedin \gamma'_\mathbf{k}]) \\
-    \also N(\mathbf{k}) &\equiv \sq{\begin{rcases} [0, 0, \dots] &\when k_b \in \psi'_\mathbf{p} \\ k &\otherwise \end{rcases} \,\middle\mid\, k \orderedin \mathbf{k}}
-  \end{aligned}
-\end{equation}
+\begin{align}
+  (\gamma'_\mathbf{k}, \kappa', \lambda', \gamma'_z) &\equiv \begin{cases}
+    (\iota, \Phi(\gamma_\mathbf{k}), \kappa, z) &\when e' > e \wedge \mathbf{H}_j = [] \\ (\gamma_\mathbf{k}, \kappa, \lambda, \gamma_z) &\otherwise
+  \end{cases} \\
+  \nonumber \where z &= \mathcal{O}([k_b \mid k \orderedin \gamma'_\mathbf{k}]) \\
+  \label{eq:blacklistfilter} \Phi(\mathbf{k}) &\equiv \sq{
+    \begin{rcases}[0, 0, \dots] &\when k_b \in \psi'_\mathbf{p} \\ k &\otherwise \end{rcases}
+    \,\middle\mid\, k \orderedin \mathbf{k}
+  }
+\end{align}
 
-Note that the posterior active validator key set $\kappa'$ is defined such that keys belonging to the historical judgement punish set $\psi'_\mathbf{p}$ are replaced with a null key containing only zeroes. The origin of this punish set is explained in section \ref{sec:judgements}.
+Note that on epoch changes the posterior active validator key set $\kappa'$ is defined such that incoming keys belonging to the historical judgement punish set $\psi'_\mathbf{p}$ are replaced with a null key containing only zeroes. The origin of this punish set is explained in section \ref{sec:judgements}.
 
 
 

--- a/text/safrole.tex
+++ b/text/safrole.tex
@@ -95,7 +95,7 @@ The set of validator keys itself is equivalent to the set of 336-octet sequences
 With a new epoch under regular conditions, validator keys get rotated and the epoch's Bandersnatch key root is updated into $\gamma'_z$:
 \begin{align}
   (\gamma'_\mathbf{k}, \kappa', \lambda', \gamma'_z) &\equiv \begin{cases}
-    (\iota, \Phi(\gamma_\mathbf{k}), \kappa, z) &\when e' > e \wedge \mathbf{H}_j = [] \\ (\gamma_\mathbf{k}, \kappa, \lambda, \gamma_z) &\otherwise
+    (\Phi(\iota), \gamma_\mathbf{k}, \kappa, z) &\when e' > e \wedge \mathbf{H}_j = [] \\ (\gamma_\mathbf{k}, \kappa, \lambda, \gamma_z) &\otherwise
   \end{cases} \\
   \nonumber \where z &= \mathcal{O}([k_b \mid k \orderedin \gamma'_\mathbf{k}]) \\
   \label{eq:blacklistfilter} \Phi(\mathbf{k}) &\equiv \sq{
@@ -104,7 +104,7 @@ With a new epoch under regular conditions, validator keys get rotated and the ep
   }
 \end{align}
 
-Note that on epoch changes the posterior active validator key set $\kappa'$ is defined such that incoming keys belonging to the historical judgement punish set $\psi'_\mathbf{p}$ are replaced with a null key containing only zeroes. The origin of this punish set is explained in section \ref{sec:judgements}.
+Note that on epoch changes the posterior queued validator key set $\gamma'_k$ is defined such that incoming keys belonging to the judgement punish set $\psi'_\mathbf{p}$ are replaced with a null key containing only zeroes. The origin of this punish set is explained in section \ref{sec:judgements}.
 
 
 

--- a/text/serialization.tex
+++ b/text/serialization.tex
@@ -132,7 +132,7 @@ A block $\mathbf{B}$ is serialized as a tuple of its elements in regular order, 
   \se(x \in \mathbb{X}) &\equiv \se(x_a, x_s, x_b, x_l)\concat\se_4(x_t)\concat\se(\maybe{x_p})\\
   \se(x \in \mathbb{S}) &\equiv \se(x_h) \concat \se_4(x_l)\concat\se(x_u) \\
   \se(x \in \mathbb{L}) &\equiv \se_4(x_s)\concat\se(x_c, x_l)\concat\se_8(x_g)\concat\se(O(x_o))\\
-  \se(x \in \mathbb{W}) &\equiv \se(x_a, \var{x_o}, x_x, x_s, \var{x_r}) \\
+  \se(x \in \mathbb{W}) &\equiv \se(x_a, x_c, \var{x_o}, x_x, x_s, \var{x_r}) \\
   \se(x \in \mathbb{P}) &\equiv \se(\var{x_\mathbf{j}}, \se_4(x_h), x_c, \var{x_\mathbf{p}}, x_\mathbf{x}, \var{x_\mathbf{i}}) \\
   \se(x \in \mathbb{C}) &\equiv \se(x_\mathbf{y}, x_r) \\
   O(o \in \mathbb{J} \cup \Y) &\equiv \begin{cases}

--- a/text/serialization.tex
+++ b/text/serialization.tex
@@ -122,11 +122,12 @@ A block $\mathbf{B}$ is serialized as a tuple of its elements in regular order, 
   \se(\mathbf{B}) &= \se\,\left\lparen\;\begin{aligned}
     &\mathbf{H},\ 
     \var{\mathbf{E}_T},\ 
-    \var{[(r, [(v, \se_2(i), s) \mid (v, i, s) \orderedin \mathbf{v}]) \mid (r, \mathbf{v}) \orderedin \mathbf{E}_J]},\\
+    \var{[(r, a, [(v, \se_2(i), s) \mid (v, i, s) \orderedin \mathbf{v}]) \mid (r, a, \mathbf{v}) \orderedin \mathbf{j}]}, \var{\mathbf{c}}, \var{\mathbf{f}},\ \\
     &\var{[\tup{s, \var{p}} \mid \tup{s, p} \orderedin \mathbf{E}_P]},\ 
     \var{\mathbf{E}_A},\ 
     \var{[\tup{c, w, \var{a}} \mid \tup{c, w, a} \orderedin \mathbf{E}_G]}
   \end{aligned}\;\right\rparen \\
+  \nonumber &\quad \where \mathbf{E}_J \equiv (\mathbf{j}, \mathbf{c}, \mathbf{f}) \\
   \se(\mathbf{H}) &= \se_U(\mathbf{H})\concat\se(\mathbf{H}_s) \\
   \se_U(\mathbf{H}) &= \se(\mathbf{H}_p,\mathbf{H}_r,\mathbf{H}_x)\concat\se_4(\mathbf{H}_t)\concat\se(\maybe{\mathbf{H}_e},\maybe{\mathbf{H}_w},\var{\mathbf{H}_j},\se_2(\mathbf{H}_k),\mathbf{H}_v)\\
   \se(x \in \mathbb{X}) &\equiv \se(x_a, x_s, x_b, x_l)\concat\se_4(x_t)\concat\se(\maybe{x_p})\\

--- a/text/work_packages_and_reports.tex
+++ b/text/work_packages_and_reports.tex
@@ -1,5 +1,15 @@
 \section{Work Packages and Work Reports}\label{sec:workpackagesandworkreports}
 
+\newcommand*{\wp¬context}{\mathbf{x}} % Consider rename to \mathbf{c}
+
+\newcommand*{\newavailabilityspecifier}{A}
+\newcommand*{\itemtoresult}{C}
+\newcommand*{\countupexports}{I}
+\newcommand*{\importsegmentdata}{M}
+\newcommand*{\pagedproofs}{P}
+\newcommand*{\marshallrefine}{R}
+\newcommand*{\extrinsicdata}{X}
+
 \subsection{Honest Behavior}
 
 We have so far specified how to recognize blocks for a correctly transitioning \Jam blockchain. Through defining the state transition function and a state Merklization function, we have also defined how to recognize a valid header. While it is not especially difficult to understand how a new block may be authored for any node which controls a key which would allow the creation of the two signatures in the header, nor indeed to fill in the other header fields, readers will note that the contents of the extrinsic remain unclear.
@@ -47,21 +57,18 @@ The guarantor is able to use this proof to justify to themselves that they are n
 
 \subsection{Packages and Items}\label{sec:packagesanditems}
 
-% TODO: Complete rename to \mathbf{c}
-\newcommand{\Tcontext}{\mathbf{x}}
-
-We begin by defining a \emph{work-package}, of set $\mathbb{P}$, and its constituent \emph{work item}s, of set $\mathbb{I}$. A work-package includes a simple blob acting as an authorization token $\mathbf{j}$, the index of the service which hosts the authorization code $h$, an authorization code hash $c$ and a parameterization blob $\mathbf{p}$, a context $\Tcontext$ and a sequence of work items $\mathbf{i}$:
+We begin by defining a \emph{work-package}, of set $\mathbb{P}$, and its constituent \emph{work item}s, of set $\mathbb{I}$. A work-package includes a simple blob acting as an authorization token $\mathbf{j}$, the index of the service which hosts the authorization code $h$, an authorization code hash $c$ and a parameterization blob $\mathbf{p}$, a context $\wp¬context$ and a sequence of work items $\mathbf{i}$:
 \begin{equation}\label{eq:workpackage}
   \mathbb{P} \equiv \tuple{\;\begin{aligned}
-    &\isa{\mathbf{j}}{\Y},\ \isa{h}{\N_\mathsf{S}},\ \isa{c}{\H},\\
-    &\isa{\mathbf{p}}{\Y},\ \isa{\Tcontext}{\mathbb{X}},\ \isa{\mathbf{i}}{\seq{\mathbb{I}}_{1:\mathsf{I}}}
+    &\isa{\mathbf{j}}{\Y},\ \isa{h}{\N_S},\ \isa{c}{\H},\\
+    &\isa{\mathbf{p}}{\Y},\ \isa{\wp¬context}{\mathbb{X}},\ \isa{\mathbf{i}}{\seq{\mathbb{I}}_{1:\mathsf{I}}}
   \end{aligned}}
 \end{equation}
 
 A work item includes: $s$ the identifier of the service to which it relates, the code hash of the service at the time of reporting $c$ (whose preimage must be available from the perspective of the lookup anchor block), a payload blob $y$, a gas limit $g$, and the three elements of its manifest, a sequence of imported data segments $\mathbf{i}$ identified by the root of the \emph{segments tree} and an index into it, $\mathbf{x}$, a sequence of hashed of data segments to be introduced in this block (and which we assume the validator knows) and $e$ the number of data segments exported by this work item:
 \begin{equation}\label{eq:workitem}
     \mathbb{I} \equiv \tuple{\begin{aligned}
-      &\isa{s}{\N_\mathsf{S}} \ts
+      &\isa{s}{\N_S} \ts
       \isa{c}{\H} \ts
       \isa{\mathbf{y}}{\Y} \ts
       \isa{g}{\N_G} \ts \\
@@ -83,16 +90,16 @@ We make an assumption that the preimage to each extrinsic hash in each work-item
 We limit the encoded size of a work-package plus the total size of the implied import and extrinsic items to 12\textsc{mb} in order to allow for around 2\textsc{mb}/s/core data throughput:
 \begin{align}
   \label{eq:checkextractsize}
-  \forall p &\in \mathbf{P}: \left(
+  \forall p &\in \mathbb{P}: \left(
   \sum_{i \in p_\mathbf{i}} |i_\mathbf{i}|\cdot\mathsf{W}_S\mathsf{W}_C + \sum_{i \in p_\mathbf{i}} \sum_{\mathcal{H}(\mathbf{x}) \in i_x} |\mathbf{x}|\right) \le \mathsf{W}_P \\
   \mathsf{W}_P &= 12\cdot2^{20}
 \end{align}
 
 %The implication of equation \ref{eq:checkextractsize} is that we have access to the preimage of all extrinsic data. For guaranteeing, this implies the work-package author probably submits the preimages alongside the work-package itself. For auditing, the extrinsic preimages may be reconstructed in the same manner as the work-package. Both are described later.
 
-We define the item-to-result function $\Gamma$ as:
+We define the item-to-result function $\itemtoresult$ as:
 \begin{equation}
-  \Gamma\colon\left\{\begin{aligned}
+  \itemtoresult\colon\left\{\begin{aligned}
     (\mathbb{I}, \Y \cup \mathbb{J}) &\to \mathbb{L}\\
     ((s, c, \mathbf{y}, g), o) &\mapsto (s, c, \mathcal{H}(\mathbf{y}), g, o)
   \end{aligned}\right.
@@ -114,9 +121,9 @@ Any of a work-package's work-items may \emph{export} segments and a \emph{segmen
 
 Guarantors are required to erasure-code and distribute two data sets: one blob, the auditable work-package containing the encoded work-package, extrinsic data and self-justifying imported segments which is placed in the short-term Audit DA store and a second set of exported-segments data together with the \emph{Paged-Proofs} metadata. Items in the first store are short-lived; assurers are expected to keep them only until finality of the block which included the work-result. Items in the second, meanwhile, are long-lived and expected to be kept for a minimum of 28 days (672 complete epochs) following the reporting of the work-report.
 
-We define the paged-proofs function $P$ which accepts a series of exported segments $\mathbf{s}$ and defines some series of additional segments placed into the Imports DA system via erasure-coding and distribution. The function evaluates to pages of hashes, together with subtree proofs, such that justifications of correctness based on a segments-root may be made from it:
+We define the paged-proofs function $\pagedproofs$ which accepts a series of exported segments $\mathbf{s}$ and defines some series of additional segments placed into the Imports DA system via erasure-coding and distribution. The function evaluates to pages of hashes, together with subtree proofs, such that justifications of correctness based on a segments-root may be made from it:
 \begin{equation}\label{eq:pagedproofs}
-  P\colon\left\{\begin{aligned}
+  \pagedproofs\colon\left\{\begin{aligned}
     \seq{\G} &\to \seq{\G} \\
     \mathbf{s} &\mapsto [\mathcal{P}_{\mathsf{W}_S}(\mathcal{J}_6(\mathbf{s}, i) \concat \wideparen{\mathbf{s}_{i\dots+64}}) \mid i \orderedin 64\cdot\N_{\ceil{\nicefrac{|\mathbf{s}|}{64}}}]
   \end{aligned}\right.
@@ -142,34 +149,35 @@ Formally:
 where:
 \begin{align*}
   \mathbf{o} &= \Psi_I(\mathbf{p}, c) \\
-  (\mathbf{r}, \overline{\mathbf{e}}) &= \transpose[(\Gamma(\mathbf{p}_\mathbf{i}[j], r), \mathbf{e}) \mid (r, \mathbf{e}) = I(\mathbf{p}, j), j \orderedin \N_{|\mathbf{p}_\mathbf{i}|}] \\
-  I(\mathbf{p}, j) &\equiv R(\mathbf{p}, \mathbf{p}_\mathbf{i}[j], \sum_{k < j}\mathbf{p}_\mathbf{i}[k]_e)\\
-  R(\mathbf{p}, i, \ell) &\equiv \Psi_R(i_c, i_g, i_s, \mathcal{H}(\mathbf{p}), i_\mathbf{y}, \mathbf{p}_\Tcontext, \mathbf{p}_a, M(i), X(i), \ell)
+  (\mathbf{r}, \overline{\mathbf{e}}) &= \transpose[(\itemtoresult(\mathbf{p}_\mathbf{i}[j], r), \mathbf{e}) \mid (r, \mathbf{e}) = \countupexports(\mathbf{p}, j), j \orderedin \N_{|\mathbf{p}_\mathbf{i}|}] \\
+  \countupexports(\mathbf{p}, j) &\equiv \marshallrefine(\mathbf{p}, \mathbf{p}_\mathbf{i}[j], \sum_{k < j}\mathbf{p}_\mathbf{i}[k]_e)\\
+  \marshallrefine(\mathbf{p}, i, \ell) &\equiv \Psi_R(i_c, i_g, i_s, \mathcal{H}(\mathbf{p}), i_\mathbf{y}, \mathbf{p}_\wp¬context, \mathbf{p}_a, \importsegmentdata(i), \extrinsicdata(i), \ell)
 \end{align*}
 
 The definition here is staged over several functions for ease of reading. The first term to be introduced, $\mathbf{o}$ is the authorization output, the result of the Is-Authorized function. The second term, $(\mathbf{r}, \overline{\mathbf{e}})$ is the sequence of results for each of the work-items in the work-package together with all segments exported by each work-item.
 
-The third and forth definition are helper terms for this, with the third performing an ordered accumulation (\ie counter) in order to ensure that the Refine function has access to the total number of exports made from the work package up to the current work-item. The fourth term, $R$, is essentially just a call to the Refine function, marshalling the relevant data from the work-package and work-item.
+The third and forth definition are helper terms for this, with the third $\countupexports$ performing an ordered accumulation (\ie counter) in order to ensure that the Refine function has access to the total number of exports made from the work package up to the current work-item. The fourth term, $\marshallrefine$, is essentially just a call to the Refine function, marshalling the relevant data from the work-package and work-item.
 
-The above relies on two functions, $M$ and $X$ which, respectively, define the import segment data and the extrinsic data for some work-item argument $i$:
+
+The above relies on two functions, $\importsegmentdata$ and $\extrinsicdata$ which, respectively, define the import segment data and the extrinsic data for some work-item argument $i$:
 \begin{equation}
   \begin{aligned}
-    M(i \in \mathbb{I}) &\equiv [\mathbf{s}[n] \mid (\mathcal{M}(\mathbf{s}), n) \orderedin i_\mathbf{i}] \\
-    X(i \in \mathbb{I}) &\equiv [x \mid \mathcal{H}(x) \orderedin i_\mathbf{x}]
+    \importsegmentdata(i \in \mathbb{I}) &\equiv [\mathbf{s}[n] \mid (\mathcal{M}(\mathbf{s}), n) \orderedin i_\mathbf{i}] \\
+    \extrinsicdata(i \in \mathbb{I}) &\equiv [x \mid \mathcal{H}(x) \orderedin i_\mathbf{x}]
   \end{aligned}
 \end{equation}
 
-We may then define $s$ as the data availability specification of the package using these two functions together with the yet to be defined \emph{Availability Specifier} function $A$ (see section \ref{sec:availabiltyspecifier}):
+We may then define $s$ as the data availability specification of the package using these two functions together with the yet to be defined \emph{Availability Specifier} function $\newavailabilityspecifier$ (see section \ref{sec:availabiltyspecifier}):
 \begin{equation}
   \begin{aligned}
-    s &= A(\mathcal{H}(\mathbf{p}), \se(\var{\mathbf{p}}, \mathbf{x}, \mathbf{i}, \mathbf{j}), \wideparen{\overline{\mathbf{e}}}) \\
-    \nonumber \where \mathbf{x} &= [[\var{\se(\mathbf{x})} \mid \mathbf{x} \in X(i)] \mid i \orderedin \mathbf{p}_\mathbf{i}]\\
-    \nonumber \also \mathbf{i} &= [M(i) \mid i \orderedin \mathbf{p}_\mathbf{i}]\\
+    s &= \newavailabilityspecifier(\mathcal{H}(\mathbf{p}), \se(\var{\mathbf{p}}, \mathbf{x}, \mathbf{i}, \mathbf{j}), \wideparen{\overline{\mathbf{e}}}) \\
+    \nonumber \where \mathbf{x} &= [[\var{\se(\mathbf{x})} \mid \mathbf{x} \in \extrinsicdata(i)] \mid i \orderedin \mathbf{p}_\mathbf{i}]\\
+    \nonumber \also \mathbf{i} &= [\importsegmentdata(i) \mid i \orderedin \mathbf{p}_\mathbf{i}]\\
     \nonumber \also \mathbf{j} &= [\mathcal{J}(\mathbf{s}, n) \mid (\mathcal{M}(\mathbf{s}), n) \orderedin i_\mathbf{i}, i \orderedin \mathbf{p}_\mathbf{i}]
   \end{aligned}
 \end{equation}
 
-Note that while $M$ and $\mathbf{j}$ are both formulated using the term $\mathbf{s}$ (all segments exported by all work packages exporting a segment to be imported) such a vast amount of data is not generally needed as the justification can be derived through a single paged-proof. This reduces the worst case data fetching for a guarantor to two segments for every one to be imported. In the case that contiguously exported segments are imported (which we might assume is a fairly common situation), then a single proof-page should be sufficient to justify many imported segments.
+Note that while $\importsegmentdata$ and $\mathbf{j}$ are both formulated using the term $\mathbf{s}$ (all segments exported by all work packages exporting a segment to be imported) such a vast amount of data is not generally needed as the justification can be derived through a single paged-proof. This reduces the worst case data fetching for a guarantor to two segments for every one to be imported. In the case that contiguously exported segments are imported (which we might assume is a fairly common situation), then a single proof-page should be sufficient to justify many imported segments.
 
 The Is-Authorized logic it references is first executed to ensure that the work-package warrants the needed core-time. Next, the guarantor should ensure that all segment-tree roots which form imported segment commitments are known and have not expired. Finally, the guarantor should ensure that they can fetch all preimage data referenced as the commitments of extrinsic segments.
 
@@ -180,9 +188,9 @@ Validators, in their role as availability assurers, should index such chunks acc
 %TODO: Make result an error if the number of exported segments > stated number of exports. (If less, then additional ones are assumed to be zeroed.)
 
 \subsubsection{Availability Specifier}\label{sec:availabiltyspecifier}
-We define the availability specifier function $A$, which creates an availability specifier from the package hash, an octet sequence of the audit-friendly work-package bundle (comprising the work-package itself, the extrinsic data and the concatenated import segments along with their proofs of correctness), and the sequence of exported segments:
+We define the availability specifier function $\newavailabilityspecifier$, which creates an availability specifier from the package hash, an octet sequence of the audit-friendly work-package bundle (comprising the work-package itself, the extrinsic data and the concatenated import segments along with their proofs of correctness), and the sequence of exported segments:
 \begin{equation}
-  \!\!\!A\colon\left\{\,\begin{aligned}
+  \!\!\!\newavailabilityspecifier\colon\left\{\,\begin{aligned}
     &\tuple{\H, \Y, \seq{\G}} \to \mathbb{S}\\
     &\tup{h, \mathbf{b},\,\mathbf{s}} \mapsto \tup{
       h,\,
@@ -197,12 +205,12 @@ We define the availability specifier function $A$, which creates an availability
     [\wideparen{\mathbf{x}} \mid \mathbf{x} \in \transpose[\mathbf{b}^\clubsuit, \mathbf{s}^\clubsuit]]
   )\\
   \also \mathbf{b}^\clubsuit &= \mathcal{H}^\#(\mathcal{C}_{\ceil{\nicefrac{|\mathbf{b}|}{\mathsf{W}_C}}}(\mathcal{P}_{\mathsf{W}_C}(\mathbf{b})))\\
-  \also \mathbf{s}^\clubsuit &= \mathcal{M}_B^\#(\transpose\mathcal{C}^\#_6(\mathbf{s} \concat P(\mathbf{s})))
+  \also \mathbf{s}^\clubsuit &= \mathcal{M}_B^\#(\transpose\mathcal{C}^\#_6(\mathbf{s} \concat \pagedproofs(\mathbf{s})))
 \end{align*}
 
 % TODO: \mathbb{S}_h is now the hash of the work-package bundle, not the work-package itself. This is a change from the original document... does anything break with it?
 
-The paged-proofs function $P$, defined earlier in equation \ref{eq:pagedproofs}, accepts a sequence of segments and returns a sequence of paged-proofs sufficient to justify the correctness of every segment. There are exactly $\ceil{\nicefrac{1}{64}}$ paged-proof segments as the number of yielded segments, each composed of a page of 64 hashes of segments, together with a Merkle proof from the root to the subtree-root which includes those 64 segments.
+The paged-proofs function $\pagedproofs$, defined earlier in equation \ref{eq:pagedproofs}, accepts a sequence of segments and returns a sequence of paged-proofs sufficient to justify the correctness of every segment. There are exactly $\ceil{\nicefrac{1}{64}}$ paged-proof segments as the number of yielded segments, each composed of a page of 64 hashes of segments, together with a Merkle proof from the root to the subtree-root which includes those 64 segments.
 
 The functions $\mathcal{M}$ and $\mathcal{M}_B$ are the fixed-depth and simple binary Merkle root functions, defined in equations \ref{eq:constantdepthmerkleroot} and \ref{eq:simplemerkleroot}. The function $\mathcal{C}$ is the erasure-coding function, defined in appendix \ref{sec:erasurecoding}.
 
@@ -217,3 +225,12 @@ And $\mathcal{P}$ is the zero-padding function to take an octet array to some mu
 Validators are incentivized to distribute each newly erasure-coded data chunk to the relevant validator, since they are not paid for guaranteeing unless a work-report is considered to be \emph{available} by a super-majority of validators. Given our work-package $\mathbf{p}$, we should therefore send the corresponding work-package bundle chunk and exported segments chunks to each validator whose keys are together with similarly corresponding chunks for imported, extrinsic and exported segments data, such that each validator can justify completeness according to the work-report's \emph{erasure-root}. In the case of a coming epoch change, they may also maximize expected reward by distributing to the new validator set.
 
 We will see this function utilized in the next sections, for guaranteeing, auditing and judging.
+
+\undef{\wp¬context}
+\undef{\newavailabilityspecifier}
+\undef{\itemtoresult}
+\undef{\countupexports}
+\undef{\importsegmentdata}
+\undef{\pagedproofs}
+\undef{\marshallrefine}
+\undef{\extrinsicdata}


### PR DESCRIPTION
- [x] Don't immediately alter kappa mid-epoch as it affects off-chain judgements.
- [x] Instead, apply the blacklist to guarantor sig verification directly.
- [x] Include the core in the WR.
- [x] Deposit the WR's signatures in with the judgement.
- [x] Require at >= 1 negative judgements to be included with a positive verdict, and place signer in punish keys.
- [x] Serialization of judgement stuff
- [x] Should always be possible to submit more guarantee signatures of a known-bad report to place them in the punish set.
  - [x] Only from lambda and kappa
- [x] Use posterior kappa for everything except judgements.
