### PR TITLE
Redefine `trap` to be a panic instead of a halt

### DIFF
--- a/text/pvm.tex
+++ b/text/pvm.tex
@@ -215,7 +215,7 @@ We assume the skip length $\ell$ is well-defined:
   \thead{$\instructions_\imath$} & \thead{\textbf{Name}} & \thead{$\gas$} & \thead{\textbf{Mutations}} \\
   \midrule
   \endhead
-  0&\token{trap}&0&$\varepsilon = \halt$\\
+  0&\token{trap}&0&$\varepsilon = \panic$\\
   \mrule
   17&\token{fallthrough}&0&\\
   \bottomrule


### PR DESCRIPTION
The GP defines the `trap` instruction to be a halt, but this instruction was always meant to be used for *abnormal* termination (and in fact the compiler *will* use it when e.g. you do a `panic!` in Rust, or an assertion fails, etc.).