### PR TITLE
Change dynamic address alignment to 2

### DIFF
--- a/text/definitions.tex
+++ b/text/definitions.tex
@@ -273,7 +273,7 @@ Here, the prime annotation indicates posterior state. Individual components may 
   \item[$\mathsf{W}_S = 6$] The size of an exported segment in erasure-coded pieces.
   \item[$\mathsf{X}$] Context strings, see below.
   \item[$\mathsf{Y} = 500$] The number of slots into an epoch at which ticket-submission ends.
-  \item[$\mathsf{Z}_A = 4$] The \textsc{pvm} dynamic address alignment factor. See equation \ref{eq:jumptablealignment}.
+  \item[$\mathsf{Z}_A = 2$] The \textsc{pvm} dynamic address alignment factor. See equation \ref{eq:jumptablealignment}.
   \item[$\mathsf{Z}_I = 2^{24}$] The standard \textsc{pvm} program initialization input data size. See equation \ref{sec:standardprograminit}.
   \item[$\mathsf{Z}_P = 2^{14}$] The standard \textsc{pvm} program initialization page size. See section \ref{sec:standardprograminit}.
   \item[$\mathsf{Z}_Q = 2^{16}$] The standard \textsc{pvm} program initialization segment size. See section \ref{sec:standardprograminit}.

--- a/text/pvm.tex
+++ b/text/pvm.tex
@@ -187,7 +187,7 @@ Any alterations of the program counter stemming from a static jump, call or bran
   \end{cases}
 \end{equation}
 
-Jumps whose next instruction is dynamically computed must use an address which may be indexed into the jump-table $\mathbf{j}$. Through a quirk of tooling\footnote{The popular code generation backend \textsc{llvm} requires and assumes in its code generation that dynamically computed jump destinations always have a certain memory alignment. Since at present we depend on this for our tooling, we must acquiesce to its assumptions.}, we define the dynamic address required by the instructions as the jump table index incremented by one and then multiplied by our jump alignment factor $\mathsf{Z}_A = 4$.
+Jumps whose next instruction is dynamically computed must use an address which may be indexed into the jump-table $\mathbf{j}$. Through a quirk of tooling\footnote{The popular code generation backend \textsc{llvm} requires and assumes in its code generation that dynamically computed jump destinations always have a certain memory alignment. Since at present we depend on this for our tooling, we must acquiesce to its assumptions.}, we define the dynamic address required by the instructions as the jump table index incremented by one and then multiplied by our jump alignment factor $\mathsf{Z}_A = 2$.
 
 As with other irregular alterations to the program counter, target code index must be the start of a basic block or else a panic occurs. Formally:
 \begin{equation}\label{eq:jumptablealignment}


### PR DESCRIPTION
Since we've added support for the `C` extension the dynamic address alignment can now be 2.