### PR TITLE
Serialization adjustments

### DIFF
--- a/text/recent_history.tex
+++ b/text/recent_history.tex
@@ -16,7 +16,7 @@ We define an item $n$ comprising the new block's header hash, its accumulation-r
 \begin{equation}
   \begin{aligned}
     \using r &= \mathcal{M}_B(\orderby{s}{\se_4(s)\frown\se(h) \mid (s, h) \in \mathbf{C}}, \mathcal{H}_K) \\
-    \using \mathbf{b} &= \mathcal{A}(\text{last}(\sq{\sq{}} \concat \sq{x_\mathbf{b} \mid x \orderedin \beta}), r)\\
+    \using \mathbf{b} &= \mathcal{A}(\text{last}(\sq{\sq{}} \concat \sq{x_\mathbf{b} \mid x \orderedin \beta}), r, \mathcal{H}_K) \\
     \using n &= \tup{
       \is{\mathbf{p}}{[((g_w)_s)_h \mid g \orderedin \xtguarantees]}\ts
       \is{h}{\mathcal{H}(\mathbf{H})}\ts\mathbf{b}\ts\is{s}{\H^0}

--- a/text/serialization.tex
+++ b/text/serialization.tex
@@ -126,7 +126,7 @@ A block $\mathbf{B}$ is serialized as a tuple of its elements in regular order, 
   \se(\mathbf{B}) &= \se\,\left\lparen\;\begin{aligned}
     &\mathbf{H},\ 
     \var{\xttickets},\ 
-    \var{[(r, a, [(v, \se_2(i), s) \mid (v, i, s) \orderedin \mathbf{j}]) \mid (r, a, \mathbf{j}) \orderedin \mathbf{v}]}, \var{\mathbf{c}}, \var{\mathbf{f}},\ \\
+    \var{[(r, \se_4(a), [(v, \se_2(i), s) \mid (v, i, s) \orderedin \mathbf{j}]) \mid (r, a, \mathbf{j}) \orderedin \mathbf{v}]}, \var{\mathbf{c}}, \var{\mathbf{f}},\ \\
     &\var{[\tup{s, \var{p}} \mid \tup{s, p} \orderedin \xtpreimages]},\ 
     \var{\xtassurances},\ 
     \var{[\tup{w, \se_4(t), \var{a}} \mid \tup{w, t, a} \orderedin \xtguarantees]}

--- a/text/serialization.tex
+++ b/text/serialization.tex
@@ -126,19 +126,19 @@ A block $\mathbf{B}$ is serialized as a tuple of its elements in regular order, 
   \se(\mathbf{B}) &= \se\,\left\lparen\;\begin{aligned}
     &\mathbf{H},\ 
     \var{\xttickets},\ 
-    \var{[(r, a, [(v, \se_2(i), s) \mid (v, i, s) \orderedin \mathbf{v}]) \mid (r, a, \mathbf{v}) \orderedin \mathbf{j}]}, \var{\mathbf{c}}, \var{\mathbf{f}},\ \\
+    \var{[(r, a, [(v, \se_2(i), s) \mid (v, i, s) \orderedin \mathbf{j}]) \mid (r, a, \mathbf{j}) \orderedin \mathbf{v}]}, \var{\mathbf{c}}, \var{\mathbf{f}},\ \\
     &\var{[\tup{s, \var{p}} \mid \tup{s, p} \orderedin \xtpreimages]},\ 
     \var{\xtassurances},\ 
     \var{[\tup{w, \se_4(t), \var{a}} \mid \tup{w, t, a} \orderedin \xtguarantees]}
   \end{aligned}\;\right\rparen \\
-  \nonumber &\quad \where \xtdisputes \equiv (\mathbf{j}, \mathbf{c}, \mathbf{f}) \\
+  \nonumber &\quad \where \xtdisputes \equiv (\mathbf{v}, \mathbf{c}, \mathbf{f}) \\
   \se(\mathbf{H}) &= \se_U(\mathbf{H})\concat\se(\mathbf{H}_s) \\
   \se_U(\mathbf{H}) &= \se(\mathbf{H}_p,\mathbf{H}_r,\mathbf{H}_x)\concat\se_4(\mathbf{H}_t)\concat\se(\maybe{\mathbf{H}_e},\maybe{\mathbf{H}_w},\var{\mathbf{H}_o},\se_2(\mathbf{H}_i),\mathbf{H}_v)\\
   \se(x \in \mathbb{X}) &\equiv \se(x_a, x_s, x_b, x_l)\concat\se_4(x_t)\concat\se(\maybe{x_p})\\
   \se(x \in \mathbb{S}) &\equiv \se(x_h) \concat \se_4(x_l)\concat\se(x_u, x_e) \\
   \se(x \in \mathbb{L}) &\equiv \se_4(x_s)\concat\se(x_c, x_l)\concat\se_8(x_g)\concat\se(O(x_o))\\
-  \se(x \in \mathbb{W}) &\equiv \se(x_a, x_c, \var{x_o}, x_x, x_s, \var{x_r}) \\
-  \se(x \in \mathbb{P}) &\equiv \se(\var{x_\mathbf{j}}, \se_4(x_h), x_c, \var{x_\mathbf{p}}, x_\mathbf{x}, \var{x_\mathbf{i}}) \\
+  \se(x \in \mathbb{W}) &\equiv \se(x_s, x_x, x_c, x_a, \var{x_o}, \var{x_r}) \\
+  \se(x \in \mathbb{P}) &\equiv \se(\var{x_\mathbf{j}}, \se_4(x_h), x_c, \var{x_\mathbf{p}}, x_\mathbf{x}, \var{x_\mathbf{w}}) \\
   % TODO: \se_4(i) should be just \se(i), but we should wait for this to be written.
   \se(x \in \mathbb{I}) &\equiv \se(\se_4(x_s), x_c, \var{x_\mathbf{y}}, \se_8(x_g), \var{\sq{(h, \se_2(i)) \mid (h, i) \orderedin x_\mathbf{i}}}, \var{\sq{(h, \se_4(i)) \mid (h, i) \orderedin x_\mathbf{x}}}, \se_2(x_e)) \\
   \se(x \in \mathbb{C}) &\equiv \se(x_\mathbf{y}, x_r) \\


### PR DESCRIPTION
- Fix serialization order in eq 283 (work report) to be coherent with eq 117:
    - 117: (s, x, c, a, o, r)
    - 283: WAS (a, c, o, x, s, r)
 
  The serialization order of items in the other types is consistent with the definitions of those types, so this may be a leftover

- Fix naming for work items entry in eq 284 ($x_i -> x_w$) to be coherent with eq 174

- Adjust naming in eq 277 of dispute verdicts to be coherent with naming used in eq 97/98
	I.e. Dispute extrinsic is now $E_D ≡ (v,c,f)$ and $(r,a,j) ∈ v$

- Encode verdict age as $E_4$

---

- **Not related to serialization**: Add hashing algorithm argument to MMR accumulate call 
