### PR TITLE
Pi' Depends on kappa'

### DIFF
--- a/text/overview.tex
+++ b/text/overview.tex
@@ -66,7 +66,7 @@ Much as in the \emph{YP}, we specify $\Upsilon$ as the implication of formulatin
     \mathbf{C}
   \end{rcases*} &\prec (\xtassurances, \rho', \delta^\dagger, \chi, \iota, \varphi) \\
   \alpha' &\prec (\xtguarantees, \varphi', \alpha) \\
-  \pi' &\prec (\xtguarantees, \xtpreimages, \xtassurances, \xttickets, \tau, \tau', \pi, \mathbf{H})
+  \pi' &\prec (\xtguarantees, \xtpreimages, \xtassurances, \xttickets, \tau, \kappa', \pi, \mathbf{H})
 \end{align}
 
 The only synchronous entanglements are visible through the intermediate components superscripted with a dagger and defined in equations \ref{eq:betadagger}, \ref{eq:deltadagger} and \ref{eq:rhoddagger}. The latter two mark a merge and join in the dependency graph and, concretely, imply that the preimage lookup extrinsic must be folded into state before the availability extrinsic may be fully processed and accumulation of work happen.


### PR DESCRIPTION
as described in formula:
π'0[v]g ≡ a[v]g + (κ'v ∈ R)

Also removed dependency on tau', as tau' is already present in H, so it is redundant.