### PR TITLE
Minor corrections

### DIFF
--- a/text/accumulation.tex
+++ b/text/accumulation.tex
@@ -71,7 +71,7 @@ We finally define the results which will be given as an operand into the accumul
 
 Within this section, we define $A$, the function which conducts the accumulation of a single service. Formally speaking, $A$ assumes omnipresence of timeslot $\mathbf{H}_t$ and some prior state components $\delta^\dagger$, $\nu$, $\mathbf{W}_\mathbf{d}$, and takes as specific arguments the service index $s \in \mathbf{S}$ (from which it may derive the wrangled results $M(s)$ and gas limit $G(s)$) and yields values for $\delta^\ddagger[s]$ and staging assignments into $\varphi$, $\iota$ together with a series of lookup solicitations/forgets, a series of deferred transfers and $\mathbf{C}$ mapping from service index to \textsc{Beefy} commitment hashes.
 
-We first denote the set of deferred transfers as $\mathbb{T}$, noting that a transfer includes a memo component $m$ of 64 octets, together with the service index of the sender $s$, the service index of the receiver $d$, the amount of tokens to be transferred $a$ and the gas limit $g$ for the transfer. Formally:
+We first denote the set of deferred transfers as $\mathbb{T}$, noting that a transfer includes a memo component $m$ of $\mathcal{M} = 128$ octets, together with the service index of the sender $s$, the service index of the receiver $d$, the amount of tokens to be transferred $a$ and the gas limit $g$ for the transfer. Formally:
 \begin{align}
   \mathbb{T} \equiv \ltuple\isa{s}{\N_S}\ts\isa{d}{\N_S}\ts\isa{a}{\N_B}\ts\isa{m}{\Y_{\mathsf{M}}}\ts\isa{g}{\N_G}\rtuple
 \end{align}

--- a/text/bandersnatch.tex
+++ b/text/bandersnatch.tex
@@ -16,3 +16,5 @@ The singly-contextualized Bandersnatch Ring\textsc{vrf} proofs $\bandersnatch{r}
   \bandersnatch{r \in \Y_R}{c \in \H}{m \in \Y} \subset \Y_{784} &\equiv \{ x \mid x \in \Y_{784}, \text{verify}(r, c, m, \text{decode}(x_{\dots32}), \text{decode}(x_{32\dots})) = \top \}  \\
   \banderout{p \in \bandersnatch{r}{c}{m}} \in \H &\equiv \text{hashed\_output}(\text{decode}(x_{\dots32}) \mid x \in \bandersnatch{r}{c}{m})
 \end{align}
+
+Note that in the case a key $\H_B$ has no corresponding Bandersnatch point, then it is disregarded from the commitment $\mathcal{O}(\seq{\H_B})$.

--- a/text/bandersnatch.tex
+++ b/text/bandersnatch.tex
@@ -17,4 +17,4 @@ The singly-contextualized Bandersnatch Ring\textsc{vrf} proofs $\bandersnatch{r}
   \banderout{p \in \bandersnatch{r}{c}{m}} \in \H &\equiv \text{hashed\_output}(\text{decode}(x_{\dots32}) \mid x \in \bandersnatch{r}{c}{m})
 \end{align}
 
-Note that in the case a key $\H_B$ has no corresponding Bandersnatch point, then it is disregarded from the commitment $\mathcal{O}(\seq{\H_B})$.
+Note that in the case a key $\H_B$ has no corresponding Bandersnatch point when constructing the ring, then the Bandersnatch \emph{padding point} should be substituted.

--- a/text/bandersnatch.tex
+++ b/text/bandersnatch.tex
@@ -17,4 +17,4 @@ The singly-contextualized Bandersnatch Ring\textsc{vrf} proofs $\bandersnatch{r}
   \banderout{p \in \bandersnatch{r}{c}{m}} \in \H &\equiv \text{hashed\_output}(\text{decode}(x_{\dots32}) \mid x \in \bandersnatch{r}{c}{m})
 \end{align}
 
-Note that in the case a key $\H_B$ has no corresponding Bandersnatch point when constructing the ring, then the Bandersnatch \emph{padding point} should be substituted.
+Note that in the case a key $\H_B$ has no corresponding Bandersnatch point when constructing the ring, then the Bandersnatch \emph{padding point} as stated by \cite{hosseini2024bandersnatch} should be substituted.

--- a/text/pvm.tex
+++ b/text/pvm.tex
@@ -121,8 +121,8 @@ We denote this set, as opcode indices rather than names, as $T$. We define the i
 We must now define the single-step \textsc{pvm} state-transition function $\Psi_1$:
 \begin{equation}
   \Psi_1\colon \left\{\begin{aligned}
-    (\Y, \seq{\N_R}, \N_R, \N_G, \regs, \ram) &\to (\{\panic, \halt, \continue \} \cup \{\fault, \host\} \times \N_R, \Z_G, \regs, \ram)\\
-    (\mathbf{c}, \mathbf{j}, \imath, \xi, \omega, \mem) &\mapsto (\varepsilon, \imath', \xi', \omega', \mem')
+    (\Y, \mathbb{B}, \seq{\N_R}, \N_R, \N_G, \regs, \ram) &\to (\{\panic, \halt, \continue \} \cup \{\fault, \host\} \times \N_R, \Z_G, \regs, \ram)\\
+    (\mathbf{c}, \mathbf{k}, \mathbf{j}, \imath, \xi, \omega, \mem) &\mapsto (\varepsilon, \imath', \xi', \omega', \mem')
   \end{aligned}\right.
 \end{equation}
 

--- a/text/pvm.tex
+++ b/text/pvm.tex
@@ -64,17 +64,19 @@ The program blob $\mathbf{p}$ is split into a series of octets which make up the
 
 The latter, dynamic jump table, is a sequence of indices into the instruction data blob and is indexed into when dynamically-computed jumps are taken. It is encoded as a sequence of natural numbers (i.e. non-negative integers) each encoded with the same length in octets. This length, term $z$ above, is itself encoded prior.
 
-The \textsc{pvm} counts instructions in octet terms (rather than in terms of instructions) and it is thus convenient to define which octets represent the beginning of an instruction, \ie the opcode octet, and which do not. This is the purpose of $\mathbf{k}$, the instruction-opcode bitmask. We assert that the length of the bitmask is no smaller than the length of the instruction blob (and in fact is simply rounded to the nearest multiple of eight for ease of octet-encoding).
+The \textsc{pvm} counts instructions in octet terms (rather than in terms of instructions) and it is thus convenient to define which octets represent the beginning of an instruction, \ie the opcode octet, and which do not. This is the purpose of $\mathbf{k}$, the instruction-opcode bitmask. We assert that the length of the bitmask is equal to the length of the instruction blob.
 
 \newcommand{\Fskip}{\text{skip}}
 
-We define the Skip function $\Fskip$ which provides the number of octets, minus one, to the next instruction's opcode, given the index of instruction's opcode index into $\mathbf{c}$ (and by extension  $\mathbf{k}$):
+We define the Skip function $\Fskip$ which provides the number of octets, minus one, to the next instruction's opcode, given the index of instruction's opcode index into $\mathbf{c}$ (and by extension $\mathbf{k}$):
 \begin{equation}
   \Fskip\colon\left\{\begin{aligned}
     \N &\to \N\\
-    i &\mapsto \min(24,\ j \in \N : \mathbf{k}_{i + 1 + j} = 1)
+    i &\mapsto \min(24,\ j \in \N : (\mathbf{k} \frown [1, 1, \dots])_{i + 1 + j} = 1)
   \end{aligned}\right.
 \end{equation}
+
+The Skip function appends $\mathbf{k}$ with a sequence of set bits in order to ensure a well-defined result for the final instruction $\Fskip(|\mathbf{c}| - 1)$.
 
 Given some instruction-index $i$, its opcode is readily expressed as $\mathbf{c}_i$ and the distance in octets to move forward to the next instruction is $1 + \Fskip(i)$. However, each instruction's ``length'' (defined as the number of contiguous octets starting with the opcode which are needed to fully define the instruction's semantics) is left implicit though limited to being at most 16.
 

--- a/text/pvm.tex
+++ b/text/pvm.tex
@@ -585,7 +585,7 @@ An extended version of the \textsc{pvm} invocation which is able to progress an 
   \Psi_H\colon \left\{\begin{aligned}
     (\Y, \N_R, \N_G, \regs, \ram, \Omega_X, X) &\to (\{\panic, \oog, \halt\} \cup \{\fault\} \times \N_R, \Z_G, \regs, \ram, X)\\
     (\mathbf{c}, \imath, \xi, \omega, \mem, f, \mathbf{x}) &\mapsto \begin{cases}
-      (\fault \times a, \imath', \xi', \omega', \mem', \mathbf{x}') &\when \bigwedge\left\{\;\begin{aligned}
+      (\fault \times a, \imath', \xi', \omega', \mem', \mathbf{x}) &\when \bigwedge\left\{\;\begin{aligned}
         &\varepsilon = \host \times h\\[2pt]
         &\fault \times a = f(h, \xi', \omega', \mem', \mathbf{x})\\[2pt]
       \end{aligned}\right.\\[8 pt]

--- a/text/pvm_invocations.tex
+++ b/text/pvm_invocations.tex
@@ -512,7 +512,7 @@ This defines a number of functions broadly of the form $(\xi' \in \Z_G, \omega' 
   \end{aligned}$\\
   \cmidrule(lr){1-1}\cmidrule(lr){2-2}
   \makecell*[l]{
-  $\Omega_X(\xi, \omega, \mu, (\mathbf{x}, \mathbf{y}), s)$ \\
+  $\Omega_Q(\xi, \omega, \mu, (\mathbf{x}, \mathbf{y}), s)$ \\
   \texttt{quit} = 12 \\
   $g = 10 + \omega_1 + 2^{32}\cdot\omega_2 $} &
   $\begin{aligned}

--- a/text/pvm_invocations.tex
+++ b/text/pvm_invocations.tex
@@ -425,7 +425,7 @@ This defines a number of functions broadly of the form $(\xi' \in \Z_G, \omega' 
   $\begin{aligned}
     \using o &= \omega_0 \\
     \using \mathbf{v} &= \begin{cases}
-      \left[\mu_{o + 176i \dots+ 176} \mid i \orderedin \N_\mathsf{V}\right] &\when \mathbb{Z}_{o \dots+ 176\mathsf{V}} \subset \mathbb{V}_{\mu} \\
+      \left[\mu_{o + 336i \dots+ 336} \mid i \orderedin \N_\mathsf{V}\right] &\when \mathbb{Z}_{o \dots+ 336\mathsf{V}} \subset \mathbb{V}_{\mu} \\
       \error &\otherwise
     \end{cases} \\
     (\omega'_0, \mathbf{x}') &= \begin{cases}

--- a/text/pvm_invocations.tex
+++ b/text/pvm_invocations.tex
@@ -497,7 +497,7 @@ This defines a number of functions broadly of the form $(\xi' \in \Z_G, \omega' 
     \using a &= 2^{32}\cdot a_h + a_l \\
     \using g &= 2^{32}\cdot g_h + g_l \\
     \using \mathbf{t} \in \mathbb{T} \cup \{\error\} &= \begin{cases}
-      (s, d, a, m, g): m = \de(\mu_{o\dots+\mathsf{M}}) &\when \N_{o\dots+\mathsf{M}} \subset \mathbb{V}_{\mu} \\
+      (s, d, a, m, g): m = \mu_{o\dots+\mathsf{M}} &\when \N_{o\dots+\mathsf{M}} \subset \mathbb{V}_{\mu} \\
       \error &\otherwise
     \end{cases} \\
     \using b &= (\mathbf{x}_\mathbf{s})_b - a \\

--- a/text/reporting_assurance.tex
+++ b/text/reporting_assurance.tex
@@ -114,13 +114,13 @@ The signature must be one whose public key is that of the validator assuring and
 
 A bit may only be set if the corresponding core has a report pending availability on it:
 \begin{align}
-  \forall a \in \xtassurances : \forall c \in \N_\mathsf{C} : a_v[c] \implies \rho^\dagger[c] \ne \none
+  \forall a \in \xtassurances : \forall c \in \N_\mathsf{C} : a_f[c] \implies \rho^\dagger[c] \ne \none
 \end{align}
 
 \subsubsection{Available Reports}
 A work-report is said to become \emph{available} if and only if there are a clear \nicefrac{2}{3} super-majority of validators who have marked its core as set within the block's assurance extrinsic. Formally, we define the series of available work-reports $\mathbf{W}$ as:
 \begin{align}\label{eq:availableworkreports}
-  \mathbf{W} &\equiv \left[\rho^\dagger[c]_w\,\middle\vert\,c \orderedin \N_\mathsf{C},\;\sum_{a \in \xtassurances}\!a_v[c]\,>\,\nicefrac{2}{3}\,\mathsf{V}\right]
+  \mathbf{W} &\equiv \left[\rho^\dagger[c]_w\,\middle\vert\,c \orderedin \N_\mathsf{C},\;\sum_{a \in \xtassurances}\!a_f[c]\,>\,\nicefrac{2}{3}\,\mathsf{V}\right]
 \end{align}
 
 This value is utilized in the definition of both $\delta'$ and $\rho^\ddagger$ which we will define presently as equivalent to $\rho^\dagger$ except for the removal of items which are now available:


### PR DESCRIPTION
- Fix discrepency between Phi and Phi_1
- Bandersnatch: Use padding point for bad keys in ring
- PVM: Fix Skip function
- PVM: A.6: x' -> x 
- PVM: Typo Omega_X should be Omega_Q
- PVM host calls: Val key is 336 long
- Accumulation: Memos are 128 bytes
- Reporting/Assurance: a_v should be a_f