### PR TITLE
Several pvm fixes

### DIFF
--- a/text/pvm.tex
+++ b/text/pvm.tex
@@ -657,7 +657,7 @@ If the above cannot be satisfied, then $x = \none$, otherwise $x = (\mathbf{c}, 
   \end{alignedat}\right.\\
 \end{equation}
 \begin{equation}
-  \forall i \in \N_{16} : \omega_i = \begin{cases}
+  \forall i \in \N_{13} : \omega_i = \begin{cases}
       2^{32} - 2^{16} &\when i = 1\\
       2^{32} - 2\mathsf{Z}_Q - \mathsf{Z}_I &\when i = 2\\
       2^{32} - \mathsf{Z}_Q - \mathsf{Z}_I &\when i = 10\\

--- a/text/pvm.tex
+++ b/text/pvm.tex
@@ -679,8 +679,8 @@ The four instances where the \textsc{pvm} is utilized each expect to be able to 
   \end{aligned}\right.\\
   \where R&\colon (\varepsilon, \imath', \xi', \omega', \mem', \mathbf{x}) \mapsto \begin{cases}
     (\oog, \mathbf{x}) &\when \varepsilon = \oog \\
-    ((\xi', \mu'_{\omega'_{10}\dots+\omega'_{11}}), \mathbf{x}) &\when \varepsilon = \halt \wedge \mathbb{Z}_{\omega'_{10}\dots+\omega'_{11}} \subset \mathbb{V}_{\mem'} \\
-    ((\xi', []), \mathbf{x}) &\when \varepsilon = \halt \wedge \mathbb{Z}_{\omega'_{10}\dots+\omega'_{11}} \not\subset \mathbb{V}_{\mem'} \\
+    ((\xi', \mu'_{\omega'_{10}\dots+\omega'_{11}}), \mathbf{x}) &\when \varepsilon = \halt \wedge \mathbb{N}_{\omega'_{10}\dots+\omega'_{11}} \subset \mathbb{V}_{\mem'} \\
+    ((\xi', []), \mathbf{x}) &\when \varepsilon = \halt \wedge \mathbb{N}_{\omega'_{10}\dots+\omega'_{11}} \not\subset \mathbb{V}_{\mem'} \\
     (\panic, \mathbf{x}) &\otherwise \\
   \end{cases}
 \end{align}

--- a/text/pvm_invocations.tex
+++ b/text/pvm_invocations.tex
@@ -345,7 +345,7 @@ The $\mathtt{gas}$ function, $\Omega_G$ has a parameter list suffixed with an el
   \end{aligned}$\\
   \cmidrule(lr){1-1}\cmidrule(lr){2-2}
   \makecell*[l]{
-  $\Omega_I(\xi, \omega, \mu, \mathbf{s}, s, \mathbf{d})$ \\
+  $\Omega_I(\xi, \omega, \mu, \mathbf{s}, s, \mathbf{d}, \mathbf{x})$ \\
   \texttt{info} = 4 \\
   $g = 10$} &
   $\begin{aligned}

--- a/text/pvm_invocations.tex
+++ b/text/pvm_invocations.tex
@@ -482,9 +482,9 @@ This defines a number of functions broadly of the form $(\xi' \in \Z_G, \omega' 
     \end{cases} \\
     \using g &= 2^{32}\cdot g_h + g_l \\
     \using m &= 2^{32}\cdot m_h + m_l \\
-    (\omega'_0, \mathbf{x}'[s]_c, \mathbf{x}'[s]_g, \mathbf{x}'[s]_m) &\equiv \begin{cases}
+    (\omega'_0, \mathbf{x}'_{n}[s]_c, \mathbf{x}'_{n}[s]_g, \mathbf{x}'_{n}[s]_m) &\equiv \begin{cases}
       (\mathtt{OK}, c, g, m) &\when c \ne \error\\
-      (\mathtt{OOB}, \mathbf{x}[s]_c, \mathbf{x}[s]_g, \mathbf{x}[s]_m) &\otherwise
+      (\mathtt{OOB}, \mathbf{x}_{n}[s]_c, \mathbf{x}_{n}[s]_g, \mathbf{x}_{n}[s]_m) &\otherwise
     \end{cases}
   \end{aligned}$\\
   \cmidrule(lr){1-1}\cmidrule(lr){2-2}

--- a/text/pvm_invocations.tex
+++ b/text/pvm_invocations.tex
@@ -534,7 +534,7 @@ This defines a number of functions broadly of the form $(\xi' \in \Z_G, \omega' 
   \end{aligned}$\\
   \cmidrule(lr){1-1}\cmidrule(lr){2-2}
   \makecell*[l]{
-  $\Omega_S(\xi, \omega, \mu, (\mathbf{x}, \mathbf{y}))$ \\
+  $\Omega_S(\xi, \omega, \mu, (\mathbf{x}, \mathbf{y}), t)$ \\
   \texttt{solicit} = 13 \\
   $g = 10$} &
   $\begin{aligned}

--- a/text/pvm_invocations.tex
+++ b/text/pvm_invocations.tex
@@ -512,7 +512,7 @@ This defines a number of functions broadly of the form $(\xi' \in \Z_G, \omega' 
   \end{aligned}$\\
   \cmidrule(lr){1-1}\cmidrule(lr){2-2}
   \makecell*[l]{
-  $\Omega_Q(\xi, \omega, \mu, (\mathbf{x}, \mathbf{y}), s)$ \\
+  $\Omega_Q(\xi, \omega, \mu, (\mathbf{x}, \mathbf{y}), s, \delta)$ \\
   \texttt{quit} = 12 \\
   $g = 10 + \omega_1 + 2^{32}\cdot\omega_2 $} &
   $\begin{aligned}

--- a/text/pvm_invocations.tex
+++ b/text/pvm_invocations.tex
@@ -502,7 +502,7 @@ This defines a number of functions broadly of the form $(\xi' \in \Z_G, \omega' 
     \end{cases} \\
     \using b &= (\mathbf{x}_\mathbf{s})_b - a \\
     (\omega'_0, \mathbf{x}'_\mathbf{t}, (\mathbf{x}'_\mathbf{s})_b) &\equiv \begin{cases}
-      (\mathtt{OOB}, \mathbf{x}_\mathbf{t}, (\mathbf{x}_\mathbf{s})_b) &\when t = \error \\
+      (\mathtt{OOB}, \mathbf{x}_\mathbf{t}, (\mathbf{x}_\mathbf{s})_b) &\when \mathbf{t} = \error \\
       (\mathtt{WHO}, \mathbf{x}_\mathbf{t}, (\mathbf{x}_\mathbf{s})_b) &\otherwhen d \not \in \keys{\delta \cup \mathbf{x}_\mathbf{n}} \\
       (\mathtt{LOW}, \mathbf{x}_\mathbf{t}, (\mathbf{x}_\mathbf{s})_b) &\otherwhen g < (\delta \cup \mathbf{x}_\mathbf{n})[d]_m \\
       (\mathtt{HIGH}, \mathbf{x}_\mathbf{t}, (\mathbf{x}_\mathbf{s})_b) &\otherwhen \xi < g \\

--- a/text/pvm_invocations.tex
+++ b/text/pvm_invocations.tex
@@ -316,7 +316,7 @@ The $\mathtt{gas}$ function, $\Omega_G$ has a parameter list suffixed with an el
   \end{aligned}$\\
   \cmidrule(lr){1-1}\cmidrule(lr){2-2}
   \makecell*[l]{
-  $\Omega_W(\xi, \omega, \mu, \mathbf{s})$ \\
+  $\Omega_W(\xi, \omega, \mu, \mathbf{s}, s)$ \\
   \texttt{write} = 3 \\
   $g = 10$
   } &

--- a/text/pvm_invocations.tex
+++ b/text/pvm_invocations.tex
@@ -39,7 +39,7 @@ The Is-Authorized invocation is the first and simplest of the four, being totall
     (\mathbf{p}, c) &\mapsto \begin{cases}
       \mathbf{r} &\otherwhen \mathbf{r} \in \{ \oog, \panic \}  \\
       \mathbf{o} &\otherwhen \mathbf{r} = \tup{g, \mathbf{o}} \\
-      \multicolumn{2}{l}{\quad\where (\mathbf{r}, \none) = \Psi_M(\mathbf{p}_\mathbf{c}, 0, \mathsf{G}_I, \mathcal{E}(\mathbf{p}, c), F, \none)}
+      \multicolumn{2}{l}{\quad\where (\mathbf{r}, \none) = \Psi_M(\mathbf{p}_\mathbf{p}, 0, \mathsf{G}_I, \mathcal{E}(\mathbf{p}, c), F, \none)}
     \end{cases} \\
   \end{aligned}\right. \\
   \label{eq:isauthorizedmutator}F&\colon\left\{\begin{aligned}

--- a/text/pvm_invocations.tex
+++ b/text/pvm_invocations.tex
@@ -674,7 +674,7 @@ These assume some refine context pair $(\mathbf{m}, \mathbf{e}) \in (\dict{\N}{\
   $\begin{aligned}
     \using [p_o, p_z, i] &= \omega_{0 \dots 3} \\
     \using \mathbf{p} &= \begin{cases}
-      \mu_{p_o\dots+p_z} &\when \mathbb{Z}_{p_o \dots+ p_z} \subset \mathbb{V}_{\mu} \\
+      \mu_{p_o\dots+p_z} &\when \mathbb{N}_{p_o \dots+ p_z} \subset \mathbb{V}_{\mu} \\
       \error &\otherwise
     \end{cases} \\
     \using n &= \min(n \in \N, n \not\in \keys{\mathbf{m}}) \\
@@ -693,8 +693,8 @@ These assume some refine context pair $(\mathbf{m}, \mathbf{e}) \in (\dict{\N}{\
     \using [n, a, b, l] &= \omega_{0 \dots 4} \\
     \using \mathbf{s} &= \begin{cases}
       \none &\when n \not\in \keys{\mathbf{m}}\\
-      \error &\when \N_{b\dots+i} \not\in \mathbb{V}_{\mathbf{m}[n]_\mathbf{u}} \\
-      \mathbf{m}[n]_{\mathbf{u}_{b\dots+i}} &\otherwise
+      \error &\when \N_{b\dots+l} \not\in \mathbb{V}_{\mathbf{m}[n]_\mathbf{u}} \\
+      \mathbf{m}[n]_{\mathbf{u}_{b\dots+l}} &\otherwise
     \end{cases}\\
     (\omega'_0, \mem') &\equiv \begin{cases}
       (\mathtt{OOB}, \mem) &\when \mathbf{s} = \error \\


### PR DESCRIPTION
This pr fixes different typos.

In order by commit:

- ΩW were missing serviceindex `s` - [commit](https://github.com/gavofyork/graypaper/commit/7196fa8b168014374fb47232ea06aa0aa84b64cf)
- ΩI was missing the **x**  parameter used when defining **t** - [commit](https://github.com/gavofyork/graypaper/commit/acfc5bcf92f2a225640620813fb831bf38496654)
- ΩU `x[s]` does not have a valid reference. it should have been `x_{n}[s]` - [commit](https://github.com/gavofyork/graypaper/commit/d608cae91b7c5d03919f9583e84fbad141e402c6)
- ΩT `t` in the first return case should be bold - [commit](https://github.com/gavofyork/graypaper/commit/6cc5e82eebaea174237d0d93863166c808964eed)
- ΩS add missing `t`parameter used  when building `bold_a` - [commit](https://github.com/gavofyork/graypaper/commit/31de68f702848398273db9e08fa848d3fa0bc55a)
- ΩP typo `i` -> `l` - [commit](https://github.com/gavofyork/graypaper/commit/f20617228bea326d3c4f4d3b8f6d53e9b91c711f)
- ΩQ missing δ - [commit](https://github.com/gavofyork/graypaper/commit/6be3b1ffe25264f6d925ad7e0b9310e3da060e21)
- (246) had 16 registers instead of 13 - [commit](https://github.com/gavofyork/graypaper/commit/37cc719433cd4460ddace091fa4e36ae58725748)
- (249) the work package set element `c`no longer exist so replaced `c` with `u` - [commit](https://github.com/gavofyork/graypaper/commit/a172efbb1e7c5a71884db363f24d845b83906e88)