### PR TITLE
fix-179: δ′ calculation after 0.4.1

### DIFF
--- a/text/accumulation.tex
+++ b/text/accumulation.tex
@@ -223,7 +223,7 @@ We have denoted the sequence of implied transfers as $\mathbf{t}$, ordered inter
 
 The posterior state $\delta'$ may then be defined as the second intermediate state with all the deferred effects of the transfers applied:
 \begin{equation}
-  \delta' = \{ s \mapsto \Psi_T(\delta^\ddagger, a, R(\mathbf{t}, s)) \mid (s \mapsto a) \in \delta^\ddagger \}
+  \delta' = \{ s \mapsto \Psi_T(\delta^\ddagger, s, R(\mathbf{t}, s)) \mid (s \mapsto a) \in \delta^\ddagger \}
 \end{equation}
 
 Note that $\Psi_T$ is defined in appendix \ref{sec:ontransferinvocation} such that it results in $\delta^\ddagger[d]$, \ie no difference to the account's intermediate state, if $R(d) = []$, \ie said account received no transfers.


### PR DESCRIPTION
ΨT has a natural `N_s` as second argument, not an account