### PR TITLE
Correction Dependencies STF gamma and kappa

### DIFF
--- a/text/overview.tex
+++ b/text/overview.tex
@@ -49,9 +49,9 @@ Much as in the \emph{YP}, we specify $\Upsilon$ as the implication of formulatin
   \tau' &\prec \mathbf{H} \\
   \beta^\dagger &\prec (\mathbf{H}, \beta) \label{eq:betadagger} \\
   \beta' &\prec (\mathbf{H}, \xtguarantees, \beta^\dagger, \beefycommitmap) \\
-  \gamma' &\prec (\mathbf{H}, \tau, \xttickets, \gamma, \iota, \eta', \kappa') \\
+  \gamma' &\prec (\mathbf{H}, \tau, \xttickets, \gamma, \iota, \eta', \kappa', \psi') \\
   \eta' &\prec (\mathbf{H}, \tau, \eta) \\
-  \kappa' &\prec (\mathbf{H}, \tau, \kappa, \gamma, \psi') \\
+  \kappa' &\prec (\mathbf{H}, \tau, \kappa, \gamma) \\
   \lambda' &\prec (\mathbf{H}, \tau, \lambda, \kappa) \\
   \psi' &\prec (\xtdisputes, \psi) \\
   \delta^\dagger &\prec (\xtpreimages, \delta, \tau') \label{eq:deltadagger} \\


### PR DESCRIPTION
- Removes `ψ'` from GP-0.4.3-eq:21 and adds `ψ'` to GP-0.4.3-eq:19. 
- Fixes: https://github.com/gavofyork/graypaper/issues/117