### PR TITLE
block seal utilizes posterior entropy

### DIFF
--- a/text/safrole.tex
+++ b/text/safrole.tex
@@ -120,13 +120,13 @@ The header must contain a valid seal and valid \textsc{vrf} output. These are tw
     \label{eq:ticketconditiontrue}
     \gamma'_\mathbf{s} \in \seq{\mathbb{C}} &\implies \left\{\,\begin{aligned}
         &i_\mathbf{y} = \banderout{\mathbf{H}_s}\,,\\
-        &\mathbf{H}_s \in \bandersig{\mathbf{H}_a}{\mathsf{X}_T \concat \eta_3 \doubleplus i_r}{\mathcal{E}_U(\mathbf{H})}\,,\\
+        &\mathbf{H}_s \in \bandersig{\mathbf{H}_a}{\mathsf{X}_T \concat \eta'_3 \doubleplus i_r}{\mathcal{E}_U(\mathbf{H})}\,,\\
         &\mathbf{T} = 1
     \end{aligned}\right.\\
     \label{eq:ticketconditionfalse}
     \gamma'_\mathbf{s} \in \seq{\H_B} &\implies \left\{\,\begin{aligned}
         &i = \mathbf{H}_a\,,\\
-        &\mathbf{H}_s \in \bandersig{\mathbf{H}_a}{\mathsf{X}_F \concat \eta_3}{\mathcal{E}_U(\mathbf{H})}\,,\\
+        &\mathbf{H}_s \in \bandersig{\mathbf{H}_a}{\mathsf{X}_F \concat \eta'_3}{\mathcal{E}_U(\mathbf{H})}\,,\\
         &\mathbf{T} = 0
     \end{aligned}\right.\\
   \mathbf{H}_v &\in \bandersig{\mathbf{H}_a}{\mathsf{X}_E\frown \banderout{\mathbf{H}_s}}{[]} \\


### PR DESCRIPTION
For correctly verify the first block of a new epoch, we must first apply the new epoch entropy (i.e., n3←n2), as the first block ticket is generated using the same logic as all other tickets (i.e., utilizing n2 from the previous epoch).