### PR TITLE
add missing u

### DIFF
--- a/text/pvm.tex
+++ b/text/pvm.tex
@@ -255,7 +255,7 @@ We assume the skip length $\ell$ is well-defined:
   \thead{$\instructions_\imath$} & \thead{\textbf{Name}} & \thead{$\gas$} & \thead{\textbf{Mutations}} \\
   \midrule
   \endhead
-  20&\token{load\_imm\_64}&0&$\reg'_A = \immed_X$\\ \mrule
+  20&\token{load\_imm\_u64}&0&$\reg'_A = \immed_X$\\ \mrule
 \bottomrule
 \end{longtable}
 


### PR DESCRIPTION
seems that   a 'u' is missing in **A.16**:
`load_imm_64` -> `load_imm_u64`