### PR TITLE
EpochMarker use η0 and η1 instead of η1' and η2'

### DIFF
--- a/text/safrole.tex
+++ b/text/safrole.tex
@@ -214,7 +214,7 @@ The epoch and winning-tickets markers are information placed in the header in or
 As mentioned earlier, the header's epoch marker $\mathbf{H}_e$ is either empty or, if the block is the first in a new epoch, then a tuple of the next and current epoch randomness, along with a sequence of Bandersnatch keys defining the Bandersnatch validator keys ($k_b$) beginning in the next epoch. Formally:
 \begin{align}\label{eq:epochmarker}
   \mathbf{H}_e &\equiv \begin{cases}
-    ( \eta'_1, \eta'_2, [ k_b \mid k \orderedin \gamma'_\mathbf{k} ] )\qquad\qquad &\when e' > e \\
+    ( \eta_0, \eta_1, [ k_b \mid k \orderedin \gamma'_\mathbf{k} ] )\qquad\qquad &\when e' > e \\
     \none & \otherwise
   \end{cases}
 \end{align}


### PR DESCRIPTION
* η0 and η1 is equivalent to η1' and η2'  based on [this](https://graypaper.fluffylabs.dev/#/911af30/0e57020e5702)
* This keeps the dependency graph [here](https://graypaper.fluffylabs.dev/#/911af30/098001098001) clean and easy to reason about.

