### PR TITLE
Corrections on 0.5.2

### DIFF
--- a/preamble.tex
+++ b/preamble.tex
@@ -102,6 +102,7 @@
 \newcommand*{\oog}{\infty}
 \newcommand*{\error}{\nabla}
 \newcommand*{\panic}{\lightning}
+\newcommand*{\badexports}{\circledcirc}
 \newcommand*{\host}{\hbar}
 \newcommand*{\halt}{\blacksquare}
 \newcommand*{\fault}{\text{\raisebox{6pt}{\rotatebox{180}{\textsf{F}}}}}

--- a/text/definitions.tex
+++ b/text/definitions.tex
@@ -264,7 +264,7 @@ Here, the prime annotation indicates posterior state. Individual components may 
   \item[$\mathsf{G}_A = 10,000,000$] The gas allocated to invoke a work-report's Accumulation logic.
   \item[$\mathsf{G}_I = 50,000,000$] The gas allocated to invoke a work-package's Is-Authorized logic.
   \item[$\mathsf{G}_R = 5,000,000,000$] The gas allocated to invoke a work-package's Refine logic.
-  \item[$\mathsf{G}_T = 350,000,000$] The total gas allocated across for all Accumulation. Should be no smaller than $\mathsf{G}_A\cdot\mathsf{C} + \sum_{g \in \mathcal{V}(\chi_\mathbf{g})}(g)$.
+  \item[$\mathsf{G}_T = 3_500,000,000$] The total gas allocated across for all Accumulation. Should be no smaller than $\mathsf{G}_A\cdot\mathsf{C} + \sum_{g \in \mathcal{V}(\chi_\mathbf{g})}(g)$.
   \item[$\mathsf{H} = 8$] The size of recent history, in blocks.
   \item[$\mathsf{I} = 4$] The maximum amount of work items in a package.
   \item[$\mathsf{J} = 8$] The maximum sum of dependency items in a work-report.

--- a/text/definitions.tex
+++ b/text/definitions.tex
@@ -261,10 +261,10 @@ Here, the prime annotation indicates posterior state. Individual components may 
   \item[$\mathsf{D} = 28,800$] The period in timeslots after which an unreferenced preimage may be expunged.
   \item[$\mathsf{E} = 600$] The length of an epoch in timeslots.
   \item[$\mathsf{F} = 2$] The audit bias factor, the expected number of additional validators who will audit a work-report in the following tranche for each no-show in the previous.
-  \item[$\mathsf{G}_A = 100,000$] The gas allocated to invoke a work-report's Accumulation logic.
-  \item[$\mathsf{G}_I = 1,000,000$] The gas allocated to invoke a work-package's Is-Authorized logic.
-  \item[$\mathsf{G}_R = 500,000,000$] The gas allocated to invoke a work-package's Refine logic.
-  \item[$\mathsf{G}_T = 35,000,000$] The total gas allocated across for all Accumulation. Should be no smaller than $\mathsf{G}_A\cdot\mathsf{C} + \sum_{g \in \mathcal{V}(\chi_\mathbf{g})}(g)$.
+  \item[$\mathsf{G}_A = 10,000,000$] The gas allocated to invoke a work-report's Accumulation logic.
+  \item[$\mathsf{G}_I = 50,000,000$] The gas allocated to invoke a work-package's Is-Authorized logic.
+  \item[$\mathsf{G}_R = 5,000,000,000$] The gas allocated to invoke a work-package's Refine logic.
+  \item[$\mathsf{G}_T = 350,000,000$] The total gas allocated across for all Accumulation. Should be no smaller than $\mathsf{G}_A\cdot\mathsf{C} + \sum_{g \in \mathcal{V}(\chi_\mathbf{g})}(g)$.
   \item[$\mathsf{H} = 8$] The size of recent history, in blocks.
   \item[$\mathsf{I} = 4$] The maximum amount of work items in a package.
   \item[$\mathsf{J} = 8$] The maximum sum of dependency items in a work-report.

--- a/text/merklization.tex
+++ b/text/merklization.tex
@@ -36,9 +36,9 @@ The state serialization is then defined as the dictionary built from the amalgam
     &&C(10) &\mapsto \se([\maybe{(w, \se_4(t))} \mid (w, t) \orderedin \rho]) \;, \\
     &&C(11) &\mapsto \se_4(\tau) \;, \\
     &&C(12) &\mapsto \se_4(\chi_m, \chi_a, \chi_v) \concat \se(\chi_\mathbf{g}) \;, \\
-    &&C(13) &\mapsto \se_4(\pi) \;, \\
-    &&C(14) &\mapsto \se([\var{i} \mid i \orderedin \ready]) \;, \\
-    &&C(15) &\mapsto \se([\var{i} \mid i \orderedin \accumulated]) \;, \\
+    &&C(13) &\mapsto \se([\se^\#_4(\mathbf{i}) \mid \mathbf{i} \orderedin \pi]) \;, \\
+    &&C(14) &\mapsto \se([\var{\mathbf{i}} \mid \mathbf{i} \orderedin \ready]) \;, \\
+    &&C(15) &\mapsto \se([\var{\mathbf{i}} \mid \mathbf{i} \orderedin \accumulated]) \;, \\
     \forall (s \mapsto \mathbf{a}) \in \delta: &&C(255, s) &\mapsto \mathbf{a}_c \concat \se_8(\mathbf{a}_b, \mathbf{a}_g, \mathbf{a}_m, \mathbf{a}_l) \concat \se_4(\mathbf{a}_i) \;, \\
     \forall (s \mapsto \mathbf{a}) \in \delta, (k \mapsto \mathbf{v}) \in \mathbf{a}_\mathbf{s}: &&C(s, \se_4(2^{32}-1) \frown k_{0\dots 28}) &\mapsto \mathbf{v} \;, \\
     \forall (s \mapsto \mathbf{a}) \in \delta, (h \mapsto \mathbf{p}) \in \mathbf{a}_\mathbf{p}: &&C(s, \se_4(2^{32}-2) \frown h_{1\dots 29}) &\mapsto \mathbf{p} \;, \\

--- a/text/pvm_invocations.tex
+++ b/text/pvm_invocations.tex
@@ -97,7 +97,7 @@ Unlike the other invocation functions, the Refine invocation function implicitly
       \Omega_K(\gascounter, \registers, \memory, (\mathbf{m}, \mathbf{e})) &\when n = \mathtt{invoke}\\
       \Omega_X(\gascounter, \registers, \memory, (\mathbf{m}, \mathbf{e})) &\when n = \mathtt{expunge}\\
       (\continue, \gascounter - 10, \registers', \memory) &\otherwise\\
-      \multicolumn{2}{l}{\where \registers' = \registers \exc \registers_7 = \mathtt{WHAT}}
+      \multicolumn{2}{l}{\where \registers' = \registers \exc \registers'_7 = \mathtt{WHAT}}
     \end{cases}
 \end{align}
 

--- a/text/pvm_invocations.tex
+++ b/text/pvm_invocations.tex
@@ -16,8 +16,7 @@
   \item[$\mathtt{CORE} = 2^{64} - 6$] Core index unknown.
   \item[$\mathtt{CASH} = 2^{64} - 7$] Insufficient funds.
   \item[$\mathtt{LOW} = 2^{64} - 8$] Gas limit too low.
-  \item[$\mathtt{HIGH} = 2^{64} - 9$] Gas limit too high.
-  \item[$\mathtt{HUH} = 2^{64} - 10$] The item is already solicited or cannot be forgotten.
+  \item[$\mathtt{HUH} = 2^{64} - 9$] The item is already solicited or cannot be forgotten.
   \item[$\mathtt{OK} = 0$] The return value indicating general success.
 \end{description}
 
@@ -509,20 +508,19 @@ Other than the gas-counter which is explicitly defined, elements of \textsc{pvm}
   \makecell*[l]{
   $\Omega_T(\gascounter, \registers, \memory, (\mathbf{x}, \mathbf{y}))$ \\
   \texttt{transfer} = 11 \\
-  $g = 10 + \registers_8 + 2^{32}\cdot\registers_9 $} &
+  $g = 10 + \registers_9 $} &
   $\begin{aligned}
-    \using [d, a, g, o] &= \registers_{7..11},  \\
+    \using [d, a, l, o] &= \registers_{7..11},  \\
     \using \mathbf{d} &= \mathbf{x}_\mathbf{d} \cup (\mathbf{x}_\mathbf{u})_\mathbf{d}\\
     \using \mathbf{t} \in \mathbb{T} \cup \{\error\} &= \begin{cases}
-      \tup{\is{s}{\mathbf{x}_s}, d, a, \is{m}{\memory_{o\dots+\mathsf{W}_T}}, g} &\when \N_{o\dots+\mathsf{W}_T} \subset \mathbb{V}_{\memory} \\
+      \tup{\is{s}{\mathbf{x}_s}, d, a, \is{m}{\memory_{o\dots+\mathsf{W}_T}}, \is{g}{l}} &\when \N_{o\dots+\mathsf{W}_T} \subset \mathbb{V}_{\memory} \\
       \error &\otherwise
     \end{cases} \\
     \using b &= (\mathbf{x}_\mathbf{s})_b - a \\
     (\registers'_7, \mathbf{x}'_\mathbf{t}, (\mathbf{x}'_\mathbf{s})_b) &\equiv \begin{cases}
       (\mathtt{OOB}, \mathbf{x}_\mathbf{t}, (\mathbf{x}_\mathbf{s})_b) &\when \mathbf{t} = \error \\
       (\mathtt{WHO}, \mathbf{x}_\mathbf{t}, (\mathbf{x}_\mathbf{s})_b) &\otherwhen d \not \in \keys{\mathbf{d}} \\
-      (\mathtt{LOW}, \mathbf{x}_\mathbf{t}, (\mathbf{x}_\mathbf{s})_b) &\otherwhen g < \mathbf{d}[d]_m \\
-      (\mathtt{HIGH}, \mathbf{x}_\mathbf{t}, (\mathbf{x}_\mathbf{s})_b) &\otherwhen \gascounter < g \\
+      (\mathtt{LOW}, \mathbf{x}_\mathbf{t}, (\mathbf{x}_\mathbf{s})_b) &\otherwhen l < \mathbf{d}[d]_m \\
       (\mathtt{CASH}, \mathbf{x}_\mathbf{t}, (\mathbf{x}_\mathbf{s})_b) &\otherwhen b < (\mathbf{x}_\mathbf{s})_t \\
       (\mathtt{OK}, \mathbf{x}_\mathbf{t} \doubleplus \mathbf{t}, b) &\otherwise
     \end{cases} \\

--- a/text/reporting_assurance.tex
+++ b/text/reporting_assurance.tex
@@ -82,10 +82,10 @@ Next, the hash of the payload ($l$) within the work item which was executed in t
 
 Finally, there is the output or error of the execution of the code $\mathbf{o}$, which may be either an octet sequence in case it was successful, or a member of the set $\mathbb{J}$, if not. This latter set is defined as the set of possible errors, formally:
 \begin{equation}
-  \mathbb{J} \in \{ \oog, \panic, \token{BAD}, \token{BIG} \}
+  \mathbb{J} \in \{ \oog, \panic, \badexports, \token{BAD}, \token{BIG} \}
 \end{equation}
 
-The first two are special values concerning execution of the virtual machine, $\oog$ denoting an out-of-gas error and $\panic$ denoting an unexpected program termination. Of the remaining two, the first indicates that the service's code was not available for lookup in state at the posterior state of the lookup-anchor block. The second indicates that the code was available but was beyond the maximum size allowed $\mathsf{W}_C$.
+The first two are special values concerning execution of the virtual machine, $\oog$ denoting an out-of-gas error and $\panic$ denoting an unexpected program termination. Of the remaining three, the first indicates that the number of exports made was invalidly reported, the second indicates that the service's code was not available for lookup in state at the posterior state of the lookup-anchor block. The third indicates that the code was available but was beyond the maximum size allowed $\mathsf{W}_C$.
 
 In order to ensure fair use of a block's extrinsic space, work-reports are limited in the maximum total size of the successful output blobs together with the authorizer output blob, effectively limiting their overall size:
 \begin{align}

--- a/text/reporting_assurance.tex
+++ b/text/reporting_assurance.tex
@@ -124,10 +124,10 @@ The signature must be one whose public key is that of the validator assuring and
   &\mathsf{X}_A \equiv \token{\$jam\_available}
 \end{align}
 
-A bit may only be set if the corresponding core has a report pending availability on it which has not timed out:
+A bit may only be set if the corresponding core has a report pending availability on it:
 \begin{align}
   &\forall a \in \xtassurances, c \in \N_\mathsf{C} :\\
-  &\quad a_f[c] \Rightarrow \rho^\dagger[c] \ne \none \wedge \mathbf{H}_t \le \rho^\dagger[c]_t + \mathsf{U}
+  &\quad a_f[c] \Rightarrow \rho^\dagger[c] \ne \none
 \end{align}
 
 \subsubsection{Available Reports}
@@ -136,10 +136,10 @@ A work-report is said to become \emph{available} if and only if there are a clea
   \mathbf{W} &\equiv \left[\rho^\dagger[c]_w\,\middle\vert\,c \orderedin \N_\mathsf{C},\;\sum_{a \in \xtassurances}\!a_f[c]\,>\,\nicefrac{2}{3}\,\mathsf{V}\right]
 \end{align}
 
-This value is utilized in the definition of both $\delta'$ and $\rho^\ddagger$ which we will define presently as equivalent to $\rho^\dagger$ except for the removal of items which are now available:
+This value is utilized in the definition of both $\delta'$ and $\rho^\ddagger$ which we will define presently as equivalent to $\rho^\dagger$ except for the removal of items which are either now available or have timed out:
 \begin{align}
   \forall c \in \N_\mathsf{C}: \rho^\ddagger[c] \equiv \begin{cases}
-    \none &\when\rho[c]_w \in \mathbf{W}\\
+    \none &\when\rho[c]_w \in \mathbf{W} \vee \mathbf{H}_t \ge \rho^\dagger[c]_t + \mathsf{U}\\
     \rho^\dagger[c] &\otherwise
   \end{cases}
 \end{align}

--- a/text/reporting_assurance.tex
+++ b/text/reporting_assurance.tex
@@ -125,10 +125,10 @@ The signature must be one whose public key is that of the validator assuring and
 \end{align}
 
 A bit may only be set if the corresponding core has a report pending availability on it:
-\begin{align}
-  &\forall a \in \xtassurances, c \in \N_\mathsf{C} :\\
-  &\quad a_f[c] \Rightarrow \rho^\dagger[c] \ne \none
-\end{align}
+\begin{equation}
+  \forall a \in \xtassurances, c \in \N_\mathsf{C} :
+  \quad a_f[c] \Rightarrow \rho^\dagger[c] \ne \none
+\end{equation}
 
 \subsubsection{Available Reports}
 A work-report is said to become \emph{available} if and only if there are a clear \nicefrac{2}{3} super-majority of validators who have marked its core as set within the block's assurance extrinsic. Formally, we define the sequence of newly available work-reports $\mathbf{W}$ as:
@@ -237,12 +237,10 @@ We denote $\mathbf{w}$ to be the set of work-reports in the present extrinsic $\
   \text{let}\ \mathbf{w} = \{ g_w \mid g \in \xtguarantees \}
 \end{align}
 
-No reports may be placed on cores with a report pending availability on it unless it has timed out. In the latter case, $\mathsf{U} = 5$ slots must have elapsed after the report was made. A report is valid only if the authorizer hash is present in the authorizer pool of the core on which the work is reported. Formally:
+No reports may be placed on cores with a report pending availability on it. A report is valid only if the authorizer hash is present in the authorizer pool of the core on which the work is reported. Formally:
 \begin{equation}\label{eq:reportcoresareunusedortimedout}
-  \forall w \in \mathbf{w} :\left\{\;\begin{aligned}
-    &\rho^\ddagger[w_c] = \none \vee \mathbf{H}_t \ge \rho^\ddagger[w_c]_t + \mathsf{U}\ , \\
-    &w_a \in \alpha[w_c]
-  \end{aligned}\right.
+  \forall w \in \mathbf{w} :
+    \rho^\ddagger[w_c] = \none \wedge w_a \in \alpha[w_c]
 \end{equation}
 
 We require that the gas allotted for accumulation of each work item in each work-report respects its service's minimum gas requirements. We also require that all work-reports total allotted accumulation gas is no greater than the overall gas limit $\mathsf{G}_A$:

--- a/text/serialization.tex
+++ b/text/serialization.tex
@@ -158,8 +158,9 @@ A block $\mathbf{B}$ is serialized as a tuple of its elements in regular order, 
     (0, \var{o}) &\when o \in \Y \\
     1 &\when o = \infty \\
     2 &\when o = \panic \\
-    3 &\when o = \token{BAD} \\
-    4 &\when o = \token{BIG} \\
+    3 &\when o = \badexports \\
+    4 &\when o = \token{BAD} \\
+    5 &\when o = \token{BIG} \\
   \end{cases}\\
   \se_I(h \in \H \cup \H^\boxplus, i \in \N_{2^{15}}) &\equiv \begin{cases}
     (h, \se_2(i)) &\when h \in \H\\

--- a/text/work_packages_and_reports.tex
+++ b/text/work_packages_and_reports.tex
@@ -179,27 +179,23 @@ Where:
   (\mathbf{r}, \overline{\mathbf{e}}) = \,&\transpose[
     (\itemtoresult(\wpX_\wp¬workitems[j], r), \mathbf{e})
     \mid
-    (r, \mathbf{e}) = \countupexports(\wpX, j),
+    (r, \mathbf{e}) = \countupexports(\wpX, j),\,
     j \orderedin \N_{|\wpX_\wp¬workitems|}
   ] \\
-  \countupexports(\wpX, j) \equiv \,&\Psi_R(
-    \wiX_c,
-    \wiX_g,
-    \wiX_s,
-    h,
-    \wiX_\mathbf{y},
-    \wpX_\wp¬context,
-    \wpX_\wp¬authorizer,
-    \mathbf{o},
-    \importsegmentdata(w, \mathbf{l}),
-    \extrinsicdata(w),
-    \ell
-  )\\
-  &\also h = \mathcal{H}(\wpX)\,,\; w = \wpX_\wp¬workitems[j]\,,\; \ell = \sum_{k < j}\wpX_\wp¬workitems[k]_\wi¬exportsegments\\
-  \forall j &\in \N_{|\wpX_\wp¬workitems|} : |\mathbf{e}| = \wpX_\mathbf{w}[j]_e\ \where (r, \mathbf{e}) = \countupexports(\wpX, j)
+  \countupexports(\wpX, j) \equiv \,&\begin{cases}
+    (r, \mathbf{e}) &\when |\mathbf{e}| = w_e \\
+    (r, [\mathbb{G}_0, \mathbb{G}_0, \dots]_{\dots w_e}) &\otherwhen r \not\in \mathbb{Y} \\
+    (\badexports, [\mathbb{G}_0, \mathbb{G}_0, \dots]_{\dots w_e}) &\otherwise \\
+    \multicolumn{2}{l}{\where (r, \mathbf{e}) = \Psi_R\left(\,\begin{aligned}
+      &\wiX_c, \wiX_g, \wiX_s, h, \wiX_\mathbf{y}, \wpX_\wp¬context,\\[2pt]
+      &\wpX_\wp¬authorizer, \mathbf{o}, \importsegmentdata(w, \mathbf{l}), \extrinsicdata(w), \ell
+    \end{aligned}\,\right)
+    }\\
+    \multicolumn{2}{l}{\also h = \mathcal{H}(\wpX)\,,\; w = \wpX_\wp¬workitems[j]\,,\; \ell = \sum_{k < j}\wpX_\wp¬workitems[k]_\wi¬exportsegments}
+  \end{cases}
 \end{align*}
 
-Note that we require the number of segments actually exported by each work-item's Refine execution to be correctly reported in the work-item's export segment count. This is to ensure that the export segment indices are correctly calculated during the Refine invocation.
+Note that we gracefully handle the case where number of segments actually exported by a work-item's Refine execution is incorrectly reported in the work-item's export segment count. In this case, the work-package continues to be valid as a whole, but the work item's exported segments are replaced by a sequence of zero-segments equal in size to the export segment count.
 
 Initially we constrain the segment-root dictionary $\mathbf{l}$: It should contain entries for all unique work-package hashes of imported segments not identified directly via a segment-root but rather through a work-package hash.
 

--- a/text/work_packages_and_reports.tex
+++ b/text/work_packages_and_reports.tex
@@ -195,8 +195,11 @@ Where:
     \extrinsicdata(w),
     \ell
   )\\
-  &\also h = \mathcal{H}(\wpX)\,,\; w = \wpX_\wp¬workitems[j]\,,\; \ell = \sum_{k < j}\wpX_\wp¬workitems[k]_\wi¬exportsegments
+  &\also h = \mathcal{H}(\wpX)\,,\; w = \wpX_\wp¬workitems[j]\,,\; \ell = \sum_{k < j}\wpX_\wp¬workitems[k]_\wi¬exportsegments\\
+  \forall j &\in \N_{|\wpX_\wp¬workitems|} : |\mathbf{e}| = \wpX_\mathbf{w}[j]_e\ \where (r, \mathbf{e}) = \countupexports(\wpX, j)
 \end{align*}
+
+Note that we require the number of segments actually exported by each work-item's Refine execution to be correctly reported in the work-item's export segment count. This is to ensure that the export segment indices are correctly calculated during the Refine invocation.
 
 Initially we constrain the segment-root dictionary $\mathbf{l}$: It should contain entries for all unique work-package hashes of imported segments not identified directly via a segment-root but rather through a work-package hash.
 


### PR DESCRIPTION
- [Definitions: Update gas limits so that gas = nanoseconds](https://github.com/gavofyork/graypaper/pull/160/commits/83f7ad5601df239040c7caa4c0b52b590205f997)
- [WP&WRs: Badly reported exports count doesn't invalidate WP](https://github.com/gavofyork/graypaper/pull/160/commits/184515d80354f96f0410b48cea950ed7c9e4f03f)
- [ReportingAssurance: Active removal of expired reports](https://github.com/gavofyork/graypaper/pull/160/commits/3e99734afc3770b145539f20b1cfa2939bbecd80)