### PR TITLE
Use beta_dagger for WR guarantees context check

### DIFF
--- a/text/reporting_assurance.tex
+++ b/text/reporting_assurance.tex
@@ -276,9 +276,9 @@ There must be no duplicate work-package hashes (\ie two work-reports of the same
   |\mathbf{p}| = |\mathbf{w}|
 \end{equation}
 
-We require that the anchor block be within the last $\mathsf{H}$ blocks and that its details be correct by ensuring that it appears within our most recent blocks $\beta$:
+We require that the anchor block be within the last $\mathsf{H}$ blocks and that its details be correct by ensuring that it appears within our most recent blocks $\beta^\dagger$:
 \begin{align}
-  \forall x \in \mathbf{x} : \exists y \in \beta : x_a = y_h \wedge x_s = y_s \wedge x_b = \mathcal{M}_R(y_\mathbf{b})\!\!\!\!\!\!
+  \forall x \in \mathbf{x} : \exists y \in \beta^\dagger : x_a = y_h \wedge x_s = y_s \wedge x_b = \mathcal{M}_R(y_\mathbf{b})\!\!\!\!\!\!
 \end{align}
 
 We require that each lookup-anchor block be within the last $\mathsf{L}$ timeslots:


### PR DESCRIPTION
We need to first update the recent block history (last block state root as per [GP 0.5.2 - 7.2](https://graypaper.fluffylabs.dev/#/5b732de/0fd5010fd501) to correctly compare state root ($y_s$) of last imported block with $x_s$  as per [GP 0.5.2 - 11.34](https://graypaper.fluffylabs.dev/#/5b732de/156701156701)