### PR TITLE
Inconsistency Designate Host Function

### DIFF
--- a/text/pvm_invocations.tex
+++ b/text/pvm_invocations.tex
@@ -447,13 +447,13 @@ Other than the gas-counter which is explicitly defined, elements of \textsc{pvm}
   $g = 10$} &
   $\begin{aligned}
     \using o &= \registers_7 \\
-    \using \mathbf{i} &= \begin{cases}
+    \using \mathbf{v} &= \begin{cases}
       \left[\memory_{o + 336i \dots+ 336} \mid i \orderedin \N_\mathsf{V}\right] &\when \mathbb{Z}_{o \dots+ 336\mathsf{V}} \subset \mathbb{V}_{\memory} \\
       \error &\otherwise
     \end{cases} \\
     (\registers'_7, (\mathbf{x}'_\mathbf{u})_\mathbf{i}) &= \begin{cases}
       (\mathtt{OOB}, (\mathbf{x}_\mathbf{u})_\mathbf{i}) &\when \mathbf{v} = \error\\
-      (\mathtt{OK}, \mathbf{i}) &\otherwise \\
+      (\mathtt{OK}, \mathbf{v}) &\otherwise \\
     \end{cases} \\
   \end{aligned}$\\
   \cmidrule(lr){1-1}\cmidrule(lr){2-2}


### PR DESCRIPTION
Fix inconsistency in `designate` host function.
https://graypaper.fluffylabs.dev/#/5b732de/306401306401

Two instances of replacing `bold_i` with `bold_v`. Suggest to not use `bold_i` here, reasons: ambiguity and inconsistency.