### PR TITLE
Fixed embedded merkle node size bit slice

### DIFF
--- a/text/merklization.tex
+++ b/text/merklization.tex
@@ -76,7 +76,7 @@ Formally, we define the encoding functions $B$ and $L$:
   L&\colon\left\{\begin{aligned}
     (\H, \Y) &\to \mathbb{B}_{512}\\
     (k, v) &\mapsto \begin{cases}
-      [1, 0] \frown \text{bits}(\se_1(|v|))_{\dots6} \frown \text{bits}(k)_{\dots248} \frown \text{bits}(v) \frown [0, 0, \dots] &\when |v| \le 32\\
+      [1, 0] \frown \text{bits}(\se_1(|v|))_{2\dots} \frown \text{bits}(k)_{\dots248} \frown \text{bits}(v) \frown [0, 0, \dots] &\when |v| \le 32\\
       [1, 1, 0, 0, 0, 0, 0, 0] \frown \text{bits}(k)_{\dots248} \frown \text{bits}(\mathcal{H}(v)) &\otherwise
     \end{cases}
   \end{aligned}\right.


### PR DESCRIPTION
See https://github.com/w3f/jamtestvectors/pull/14#issuecomment-2549423040


<img width="719" alt="image" src="https://github.com/user-attachments/assets/aa27e702-c051-4be7-a0e5-7979c6f9bb60" />
