### PR TITLE
Deferred Transfer encoding

### DIFF
--- a/text/serialization.tex
+++ b/text/serialization.tex
@@ -154,6 +154,7 @@ A block $\mathbf{B}$ is serialized as a tuple of its elements in regular order, 
     \se_2(x_e)
   ) \\
   \se(x \in \mathbb{C}) &\equiv \se(x_\mathbf{y}, x_r) \\
+  \se(x \in \defxfer) &\equiv \se(\se_4(x_s), \se_4(x_d), \se_8(x_a), \se(x_m), \se_8(x_g)) \\
   O(o \in \mathbb{J} \cup \Y) &\equiv \begin{cases}
     (0, \var{o}) &\when o \in \Y \\
     1 &\when o = \infty \\


### PR DESCRIPTION
B.14, On-Transfer Invocation calls for encoding of sequence of T deferred transfer
![image](https://github.com/user-attachments/assets/cfd811d5-b75d-41f6-acc6-14757abf216e)

this PR adds the otherwise missing encoding specification



