### PR TITLE
length discriminator encoding on ϑ dependencies

### DIFF
--- a/text/merklization.tex
+++ b/text/merklization.tex
@@ -37,7 +37,7 @@ The state serialization is then defined as the dictionary built from the amalgam
     &&C(11) &\mapsto \se_4(\tau) \;, \\
     &&C(12) &\mapsto \se_4(\chi_m, \chi_a, \chi_v) \concat \se(\chi_\mathbf{g}) \;, \\
     &&C(13) &\mapsto \se([\se^\#_4(\mathbf{i}) \mid \mathbf{i} \orderedin \pi]) \;, \\
-    &&C(14) &\mapsto \se([\var{\mathbf{i}} \mid \mathbf{i} \orderedin \ready]) \;, \\
+    &&C(14) &\mapsto \se([\var{(\mathbf{w}, \var{\mathbf{d}})} \mid (\mathbf{w}, \mathbf{d}) \orderedin \mathbf{i} \mid \mathbf{i} \orderedin \ready]) \;, \\
     &&C(15) &\mapsto \se([\var{\mathbf{i}} \mid \mathbf{i} \orderedin \accumulated]) \;, \\
     \forall (s \mapsto \mathbf{a}) \in \delta: &&C(255, s) &\mapsto \mathbf{a}_c \concat \se_8(\mathbf{a}_b, \mathbf{a}_g, \mathbf{a}_m, \mathbf{a}_l) \concat \se_4(\mathbf{a}_i) \;, \\
     \forall (s \mapsto \mathbf{a}) \in \delta, (k \mapsto \mathbf{v}) \in \mathbf{a}_\mathbf{s}: &&C(s, \se_4(2^{32}-1) \frown k_{0\dots 28}) &\mapsto \mathbf{v} \;, \\


### PR DESCRIPTION
add length discriminator to the encoding of the set of dependencies of ready to accumulate state item
![image](https://github.com/user-attachments/assets/fe2d2ad1-c7dd-44d4-97d7-10253c54e09a)
https://graypaper.fluffylabs.dev/#/6e1c0cd/37f40137f401