### PR TITLE
chore(overview): add tau to the dependencies of disputes

### DIFF
--- a/text/overview.tex
+++ b/text/overview.tex
@@ -53,7 +53,7 @@ Much as in the \emph{YP}, we specify $\Upsilon$ as the implication of formulatin
   \eta' &\prec (\mathbf{H}, \tau, \eta) \\
   \kappa' &\prec (\mathbf{H}, \tau, \kappa, \gamma) \\
   \lambda' &\prec (\mathbf{H}, \tau, \lambda, \kappa) \\
-  \psi' &\prec (\xtdisputes, \psi) \\
+  \psi' &\prec (\xtdisputes, \tau, \psi) \\
   \rho^\dagger &\prec (\xtdisputes, \rho) \label{eq:rhodagger} \\
   \rho^\ddagger &\prec (\xtassurances, \rho^\dagger) \label{eq:rhoddagger} \\
   \rho' &\prec (\xtguarantees, \rho^\ddagger, \kappa, \tau') \\


### PR DESCRIPTION

tau(time slot) is used for checking the age of verdicts in the state transition of psi(disputes), see also graypaper 10.2 >> (10.2):

https://github.com/gavofyork/graypaper/blob/16d9709d14a2afaeaefe9fbdca07d58cfcdc88c9/text/judgments.tex#L41