### PR TITLE
PVM: add missing sign extension to `div_u_32`

### DIFF
--- a/text/pvm.tex
+++ b/text/pvm.tex
@@ -609,7 +609,7 @@ Note, the term $h$ above refers to the beginning of the heap, the second major s
   192&\token{mul\_32}&0&$\reg'_D = \sext_4((\reg_A \cdot \reg_B) \bmod 2^{32})$\\ \mrule
   193&\token{div\_u\_32}&0&$\reg'_D = \begin{cases}
     2^{64} - 1 &\when \reg_B \bmod 2^{32} = 0\\
-    \floor{(\reg_A \bmod 2^{32}) \div (\reg_B \bmod 2^{32})} &\otherwise
+    \sext_4(\floor{(\reg_A \bmod 2^{32}) \div (\reg_B \bmod 2^{32})}) &\otherwise
   \end{cases}$\\ \mrule
   194&\token{div\_s\_32}&0&$\reg'_D = \begin{cases}
     2^{64} - 1 &\when b = 0\\


### PR DESCRIPTION
As reported here: https://github.com/w3f/jamtestvectors/pull/3#issuecomment-2626488823