### PR TITLE
PVM: Add unsigned conversion to max/min results

### DIFF
--- a/text/pvm.tex
+++ b/text/pvm.tex
@@ -686,9 +686,9 @@ Note, the term $h$ above refers to the beginning of the heap, the second major s
   224&\token{and\_inv}&0&$\forall i \in \N_{64} : \bits{\reg'_D}_i = \bits{\reg_A}_i \wedge \lnot \bits{\reg_B}_i$\\ \mrule
   225&\token{or\_inv}&0&$\forall i \in \N_{64} : \bits{\reg'_D}_i = \bits{\reg_A}_i \vee \lnot \bits{\reg_B}_i$\\ \mrule
   226&\token{xnor}&0&$\forall i \in \N_{64} : \bits{\reg'_D}_i = \lnot ( \bits{\reg_A}_i \oplus \bits{\reg_B}_i )$\\ \mrule
-  227&\token{max}&0&$\reg'_D = \max ( \signed{\reg_A}, \signed{\reg_B} )$\\ \mrule
+  227&\token{max}&0&$\reg'_D = \unsigned{\max ( \signed{\reg_A}, \signed{\reg_B} )}$\\ \mrule
   228&\token{max\_u}&0&$\reg'_D = \max ( \reg_A, \reg_B )$\\ \mrule
-  229&\token{min}&0&$\reg'_D = \min ( \signed{\reg_A}, \signed{\reg_B} )$\\ \mrule
+  229&\token{min}&0&$\reg'_D = \unsigned{\min ( \signed{\reg_A}, \signed{\reg_B} )}$\\ \mrule
   230&\token{min\_u}&0&$\reg'_D = \min ( \reg_A, \reg_B )$\\
 \bottomrule
 \end{longtable}


### PR DESCRIPTION
- Added unsigned conversion to `max`/`min` results so they can be assigned to the destination register