### PR TITLE
Set H_a with Bandersnatch key and not the entire key-set

### DIFF
--- a/text/header.tex
+++ b/text/header.tex
@@ -44,7 +44,7 @@ We assume the state-Merklization function $\mathcal{M}_\sigma$ is capable of tra
 
 All blocks have an associated public key to identify the author of the block. We identify this as an index into the posterior current validator set $\kappa'$. We denote the Bandersnatch key of the author as $\mathbf{H}_a$ though note that this is merely an equivalence, and is not serialized as part of the header.
 \begin{equation}
-  \mathbf{H}_i \in \N_\mathsf{V} \,,\quad \mathbf{H}_a \equiv \kappa'[\mathbf{H}_i]
+  \mathbf{H}_i \in \N_\mathsf{V} \,,\quad \mathbf{H}_a \equiv \kappa'[\mathbf{H}_i]_b
 \end{equation}
 
 \subsection{The Markers}\label{sec:markers}


### PR DESCRIPTION
This PR sets `H_a` (GP-0.6.2-eq:5.9) with Bandersnatch key and not the entire key-set by adding attribute `b` as specified by GP-0.6.2-eq:6.9.

Supported by:
- GP text above equation 5.9 that states H_a only concerns the Bandersnatch key.
- The use of H_a in utility function Y.