### PR TITLE
Two fixes for incorrect references to \H^0

### DIFF
--- a/text/merklization.tex
+++ b/text/merklization.tex
@@ -107,7 +107,7 @@ The underlying function for our Merkle trees is the \emph{node} function $N$, wh
   N\colon\left\{\begin{aligned}
     (\seq{\Y_n}, \Y \to \H) &\to \Y_n \cup \H \\
     (\mathbf{v}, H) &\mapsto \begin{cases}
-      \H_0 &\when |\mathbf{v}| = 0 \\
+      \H^0 &\when |\mathbf{v}| = 0 \\
       \mathbf{v}_0 &\when |\mathbf{v}| = 1 \\
       H(\token{\$node} \concat N(\mathbf{v}_{\dots\ceil{\nicefrac{|\mathbf{v}|}{2}}}, H) \concat N(\mathbf{v}_{\ceil{\nicefrac{|\mathbf{v}|}{2}}\dots}, H)) &\otherwise
     \end{cases}
@@ -241,7 +241,7 @@ We define the \textsc{mmr} super-peak function as $\mathcal{M}_R$:
   \mathcal{M}_R\colon\deffunc{
     \seq{\H?} &\to \H \\
     \mathbf{b} &\mapsto \begin{cases}
-      \H_0 &\when |\mathbf{h}| = 0\\
+      \H^0 &\when |\mathbf{h}| = 0\\
       \mathbf{h}_0 &\when |\mathbf{h}| = 1\\
       \mathcal{H}_K(\token{\$peak} \concat \mathcal{M}_R(\mathbf{h}_{\dots|\mathbf{h}|-1}) \concat \mathbf{h}_{|\mathbf{h}|-1}) &\otherwise \\
       \multicolumn{2}{l}{\where \mathbf{h} = \sq{h \mid h \orderedin \mathbf{b}, h \ne \none}}


### PR DESCRIPTION
Substituted two occurrences of \H_0 to \H^0