### PR TITLE
 PVM: Instruction 180 (group variables)

### DIFF
--- a/text/pvm.tex
+++ b/text/pvm.tex
@@ -575,7 +575,7 @@ Note, the term $h$ above refers to the beginning of the heap, the second major s
     \reg'_B \equiv \reg'_{r_B} \\
     \using l_X &= \min(4, \instructions_{\imath+2} \bmod 8) \,,\quad&
     \immed_X &= \sext_{l_X}(\de_{l_X}(\instructions_{\imath+3\dots+l_X})) \\
-    \using l_Y &= \min(4, \max(0, \ell - l_X - 2)) \,,\quad&
+    \using l_Y &= \min(4, \max(0, \ell - l_X - 3)) \,,\quad&
     \immed_Y &= \sext_{l_Y}(\de_{l_Y}(\instructions_{\imath+3+l_X\dots+l_Y}))
   \end{aligned}
 \end{equation}


### PR DESCRIPTION
Correction to instruction group variables for instructions with Two Registers and Two Immediates.
https://graypaper.fluffylabs.dev/#/5f542d7/29b00129ca01
This impacts instruction 180: `load_imm_jump_ind`.

Current test vectors `inst_load_imm_and_jump_indirect_*.json` do not catch this problem because in all cases a `trap` instruction (`0`) is found after the `basic_block` for instruction 180.

This error was found running tests against our implementation for: [riscv_rv64ui_jalr.json](https://github.com/w3f/jamtestvectors/blob/cd85648f2f3c67025f4f5001657a0ce7cf4c5377/pvm/programs/riscv_rv64ui_jalr.json)

PS
Interestingly enough FluffyLabs (@tomusdrw) PVM Debugger (https://pvm.fluffylabs.dev) seems to process all mentioned test vectors (including the RISCV vectors) correctly. This either means they implemented the change in this PR (and did NOT create a PR for the suggested modification of GP) or something else is wrong, such as an interpretation or implementation error on our end. Anyway enough IMO to get an extra set of eyes on this @koute.