### PR TITLE
Intro: Change "size-synchrony" to "size-coherency"

### DIFF
--- a/text/intro.tex
+++ b/text/intro.tex
@@ -25,7 +25,7 @@ Beyond resilience and generality, things get more interesting, and we must look 
   \item \label{enum:accessibility} Accessibility: negligible barriers to innovation; easy, fast, cheap and permissionless.
 \end{enumerate}
 
-As a declared Web3 technology, we make an implicit assumption of the first two items. Interestingly, items \ref{enum:performance} and \ref{enum:coherency} are antagonistic according to an information theoretic principle which we are sure must already exist in some form but are nonetheless unaware of a name for it. For argument's sake we shall name it \emph{size-synchrony antagonism}.
+As a declared Web3 technology, we make an implicit assumption of the first two items. Interestingly, items \ref{enum:performance} and \ref{enum:coherency} are antagonistic according to an information theoretic principle which we are sure must already exist in some form but are nonetheless unaware of a name for it. For argument's sake we shall name it \emph{size-coherency antagonism}.
 
 \subsection{Scaling under Size-Coherency Antagonism}
 


### PR DESCRIPTION
"Size-synchrony antagonism" is used only once, but it must refer to the "size-coherency antagonism" discussed in the next chapter (and to "coherency" defined above).

Also added newline at end of file.