### PR TITLE
Update stf dependency order for β′

### DIFF
--- a/text/overview.tex
+++ b/text/overview.tex
@@ -48,7 +48,6 @@ Much as in the \emph{YP}, we specify $\Upsilon$ as the implication of formulatin
 \begin{align}\label{eq:transitionfunctioncomposition}
   \tau' &\prec \mathbf{H} \\
   \beta^\dagger &\prec (\mathbf{H}, \beta) \label{eq:betadagger} \\
-  \beta' &\prec (\mathbf{H}, \xtguarantees, \beta^\dagger, \beefycommitmap) \\
   \gamma' &\prec (\mathbf{H}, \tau, \xttickets, \gamma, \iota, \eta', \kappa', \psi') \\
   \eta' &\prec (\mathbf{H}, \tau, \eta) \\
   \kappa' &\prec (\mathbf{H}, \tau, \kappa, \gamma) \\
@@ -59,6 +58,7 @@ Much as in the \emph{YP}, we specify $\Upsilon$ as the implication of formulatin
   \rho' &\prec (\xtguarantees, \rho^\ddagger, \kappa, \tau') \\
   \mathbf{W}^* &\prec (\xtassurances, \rho') \\
   (\ready', \accumulated', \accountspostxfer, \chi', \iota', \varphi', \beefycommitmap) &\prec (\mathbf{W}^*, \ready, \accumulated, \accountspre, \chi, \iota, \varphi) \\
+  \beta' &\prec (\mathbf{H}, \xtguarantees, \beta^\dagger, \beefycommitmap) \\
   \accountspostpreimage &\prec (\xtpreimages, \accountspostxfer, \tau') \label{eq:accountspostpreimage} \\
   \alpha' &\prec (\mathbf{H}, \xtguarantees, \varphi', \alpha) \\
   \pi' &\prec (\xtguarantees, \xtpreimages, \xtassurances, \xttickets, \tau, \kappa', \pi, \mathbf{H})\!\!\!\!\!\!\!\!


### PR DESCRIPTION
β′ requires the commitment map which doesn't exist at it's current point in the dependency graph.

This PR corrects the order.