### PR TITLE
Definitions: Correct constant `D` value

### DIFF
--- a/text/definitions.tex
+++ b/text/definitions.tex
@@ -260,7 +260,7 @@ Here, the prime annotation indicates posterior state. Individual components may 
   \item[$\mathsf{B}_L = 1$] The additional minimum balance required per octet of elective service state.
   \item[$\mathsf{B}_S = 100$] The basic minimum balance which all services require.
   \item[$\mathsf{C} = 341$] The total number of cores.
-  \item[$\mathsf{D} = 28,800$] The period in timeslots after which an unreferenced preimage may be expunged.
+  \item[$\mathsf{D} = 4,800$] The period in timeslots after which an unreferenced preimage may be expunged.
   \item[$\mathsf{E} = 600$] The length of an epoch in timeslots.
   \item[$\mathsf{F} = 2$] The audit bias factor, the expected number of additional validators who will audit a work-report in the following tranche for each no-show in the previous.
   \item[$\mathsf{G}_A = 10,000,000$] The gas allocated to invoke a work-report's Accumulation logic.


### PR DESCRIPTION
Update constant `D` from 28,000 to 4,800 to align with [this commit](https://github.com/gavofyork/graypaper/commit/19ebc483086d40d37531c0a43d51a49bcc61d859) and [its usage in the PVM invocations section](https://github.com/gavofyork/graypaper/blob/main/text/pvm_invocations.tex#L58)