### PR TITLE
Use explicit tuple keys for preimage lookup metadata dictionaries

### DIFF
--- a/text/accounts.tex
+++ b/text/accounts.tex
@@ -106,7 +106,7 @@ The historical lookup function $\Lambda$ may now be defined as:
   \begin{aligned}\label{eq:historicallookup}
     &\Lambda\colon (\mathbb{A}, \N_T, \H) \to \Y\bm{?} \\
     &\Lambda(\mathbf{a}, t, h) \equiv \begin{cases}
-      \mathbf{a}_\mathbf{p}[h]\!\!\!\! &\when h \in \keys{\mathbf{a}_\mathbf{p}} \wedge I(\mathbf{a}_\mathbf{l}[h, |\mathbf{a}_\mathbf{p}[h]|], t) \!\!\!\!\! \\
+      \mathbf{a}_\mathbf{p}[h]\!\!\!\! &\when h \in \keys{\mathbf{a}_\mathbf{p}} \wedge I(\mathbf{a}_\mathbf{l}[\tup{h, |\mathbf{a}_\mathbf{p}[h]|}], t) \!\!\!\!\! \\
       \none &\otherwise
     \end{cases}\\
     &\where I(\mathbf{l}, t) = \begin{cases}

--- a/text/accumulation.tex
+++ b/text/accumulation.tex
@@ -246,6 +246,6 @@ We disregard, without prejudice, any preimages which due to the effects of accum
     \}\\
   \accountspostpreimage = \accountspostxfer \text{ ex. } \forall \tup{s\ts\mathbf{p}} \in \mathbf{P} : \left\{\,\begin{aligned}
       \quad\accountspostpreimage[s]_\mathbf{p}[\mathcal{H}(\mathbf{p})] &= \mathbf{p} \\
-      \accountspostpreimage[s]_\mathbf{l}[\mathcal{H}(\mathbf{p}), |\mathbf{p}|] &= [\tau']
+      \accountspostpreimage[s]_\mathbf{l}[\tup{\mathcal{H}(\mathbf{p}), |\mathbf{p}|}] &= [\tau']
     \end{aligned}\right.\!\!\!\!
 \end{align}

--- a/text/pvm_invocations.tex
+++ b/text/pvm_invocations.tex
@@ -538,7 +538,7 @@ Other than the gas-counter which is explicitly defined, elements of \textsc{pvm}
       (\panic, \registers_7, (\mathbf{x}_\mathbf{u})_\mathbf{d}) &\when h = \error \\
       (\continue, \mathtt{WHO}, (\mathbf{x}_\mathbf{u})_\mathbf{d}) &\otherwhen \mathbf{d} = \error \vee \mathbf{d}_c \ne \se_{32}(\mathbf{x}_s) \\
       (\continue, \mathtt{HUH}, (\mathbf{x}_\mathbf{u})_\mathbf{d}) &\otherwhen \mathbf{d}_i \ne 2 \vee (h, l) \not\in \mathbf{d}_\mathbf{l} \\
-      (\continue, \mathtt{OK}, (\mathbf{x}_\mathbf{u})_\mathbf{d} \setminus \{d\} \cup \{ \mathbf{x}_s \mapsto \mathbf{s}' \}) &\otherwhen \mathbf{d}_\mathbf{l}[h, l] = [x, y], y < t - \mathsf{D} \\
+      (\continue, \mathtt{OK}, (\mathbf{x}_\mathbf{u})_\mathbf{d} \setminus \{d\} \cup \{ \mathbf{x}_s \mapsto \mathbf{s}' \}) &\otherwhen \mathbf{d}_\mathbf{l}[\tup{h, l}] = [x, y], y < t - \mathsf{D} \\
       (\continue, \mathtt{HUH}, (\mathbf{x}_\mathbf{u})_\mathbf{d}) &\otherwise \\
     \end{cases} \\
   \end{aligned}$\\
@@ -554,7 +554,7 @@ Other than the gas-counter which is explicitly defined, elements of \textsc{pvm}
       \error &\otherwise
     \end{cases} \\
     \using \mathbf{a} &= \begin{cases}
-      (\mathbf{x}_\mathbf{s})_\mathbf{l}[h, z] &\when (h, z) \in \keys{(\mathbf{x}_\mathbf{s})_\mathbf{l}}\\
+      (\mathbf{x}_\mathbf{s})_\mathbf{l}[\tup{h, z}] &\when (h, z) \in \keys{(\mathbf{x}_\mathbf{s})_\mathbf{l}}\\
       \error &\otherwise\\
     \end{cases} \\
     (\execst', \registers'_7, \registers'_8) &\equiv \begin{cases}
@@ -608,9 +608,9 @@ Other than the gas-counter which is explicitly defined, elements of \textsc{pvm}
           \keys{\mathbf{a}_\mathbf{l}} &= \keys{(\mathbf{x}_\mathbf{s})_\mathbf{l}} \setminus \{\tup{h, z}\}\ ,\\[2pt]
           \keys{\mathbf{a}_\mathbf{p}} &= \keys{(\mathbf{x}_\mathbf{s})_\mathbf{p}} \setminus \{h\}
         \end{aligned}
-      \ \right\} &\when (\mathbf{x}_\mathbf{s})_\mathbf{l}[h, z] \in \{[], [x, y]\},\ y < t - \mathsf{D} \\
-      \quad \mathbf{a}_\mathbf{l}[h, z] = [x, t] &\when (\mathbf{x}_\mathbf{s})_\mathbf{l}[h, z] = [x] \\
-      \quad \mathbf{a}_\mathbf{l}[h, z] = [w, t] &\when (\mathbf{x}_\mathbf{s})_\mathbf{l}[h, z] = [x, y, w],\ y < t - \mathsf{D} \\
+      \ \right\} &\when (\mathbf{x}_\mathbf{s})_\mathbf{l}[\tup{h, z}] \in \{[], [x, y]\},\ y < t - \mathsf{D} \\
+      \quad \mathbf{a}_\mathbf{l}[\tup{h, z}] = [x, t] &\when (\mathbf{x}_\mathbf{s})_\mathbf{l}[\tup{h, z}] = [x] \\
+      \quad \mathbf{a}_\mathbf{l}[\tup{h, z}] = [w, t] &\when (\mathbf{x}_\mathbf{s})_\mathbf{l}[\tup{h, z}] = [x, y, w],\ y < t - \mathsf{D} \\
       \error &\otherwise\\
     \end{cases} \\
     (\execst', \registers'_7, \mathbf{x}'_\mathbf{s}) &\equiv \begin{cases}


### PR DESCRIPTION
# Summary
When accessing entries of service preimage lookup dictionary (`l`), omitting parentheses from tuple keys is understandable given the clear definition of the dictionary. However, suggesting explicitly using tuple keys for consistency, as seen [here](https://github.com/gavofyork/graypaper/blob/main/text/accumulation.tex#L236) and [here](https://github.com/gavofyork/graypaper/blob/main/text/pvm_invocations.tex#L582-L583).

# Updates

### Historical Lookup Function
(prev)
<img width="429" alt="prev_lookup_function" src="https://github.com/user-attachments/assets/ff583422-0fca-4cd1-93c5-77993e82e2aa" />

(updated)
<img width="418" alt="lookup_function" src="https://github.com/user-attachments/assets/b17c23bf-4931-425b-aa98-cd5e19739a80" />

### Preimages Integration STF
(prev)
<img width="417" alt="prev_preimages_stf" src="https://github.com/user-attachments/assets/f41a9924-d46a-4e46-a826-ed675eac0f24" />

(updated)
<img width="441" alt="preimages_stf" src="https://github.com/user-attachments/assets/b9f3d7c3-c6ee-4b00-9fde-afd97d7ee44e" />

### `eject` host function
(prev)
<img width="832" alt="prev_host_eject" src="https://github.com/user-attachments/assets/299bb7e4-3ce6-4449-a110-a271f38d9371" />

(updated)
<img width="896" alt="host_eject" src="https://github.com/user-attachments/assets/760655c9-f6ef-438f-b305-f98ab7dcd406" />

### `query` host function
(prev)
<img width="830" alt="prev_host_query" src="https://github.com/user-attachments/assets/c84d7db9-f31a-41a4-96c0-d570dbd97fbb" />

(updated)
<img width="881" alt="host_query" src="https://github.com/user-attachments/assets/3216c7e1-90a4-4f18-941f-7a342e2fb472" />

### `forget` host function
(prev)
<img width="830" alt="prev_host_forget" src="https://github.com/user-attachments/assets/c5b1b0cd-04be-4641-a6df-d3d4d63c854b" />

(updated)
<img width="886" alt="host_forget" src="https://github.com/user-attachments/assets/78c379d6-0cb3-45cb-b96d-35be4552ec04" />