### PR TITLE
Add tau & tau_prime as state transition input dependency (2nd try)

### DIFF
--- a/text/overview.tex
+++ b/text/overview.tex
@@ -57,7 +57,7 @@ Much as in the \emph{YP}, we specify $\Upsilon$ as the implication of formulatin
   \rho^\ddagger &\prec (\xtassurances, \rho^\dagger) \label{eq:rhoddagger} \\
   \rho' &\prec (\xtguarantees, \rho^\ddagger, \kappa, \tau') \\
   \mathbf{W}^* &\prec (\xtassurances, \rho') \\
-  (\ready', \accumulated', \accountspostxfer, \chi', \iota', \varphi', \beefycommitmap) &\prec (\mathbf{W}^*, \ready, \accumulated, \accountspre, \chi, \iota, \varphi) \\
+  (\ready', \accumulated', \accountspostxfer, \chi', \iota', \varphi', \beefycommitmap) &\prec (\mathbf{W}^*, \ready, \accumulated, \accountspre, \chi, \iota, \varphi, \tau, \tau') \\
   \beta' &\prec (\mathbf{H}, \xtguarantees, \beta^\dagger, \beefycommitmap) \\
   \accountspostpreimage &\prec (\xtpreimages, \accountspostxfer, \tau') \label{eq:accountspostpreimage} \\
   \alpha' &\prec (\mathbf{H}, \xtguarantees, \varphi', \alpha) \\


### PR DESCRIPTION
NOTE: supersedes https://github.com/gavofyork/graypaper/pull/241 (fixes mistake and resolves merge conflict).

Adds tau `τ` & tau_prime `τ'` as state transition input dependency in GP-0.6.2-eq:4.17 (1)

# Supported by use in
- GP-0.6.2-eq:12.24 (setting delta_doubledagger `δ‡`) (2)
- GP-0.6.2-eq:12.27 (setting theta_prime `ϑ'`) (3)

# References
1. [GP-0.6.2-eq:4.17](https://graypaper.fluffylabs.dev/#/5f542d7/093a01093a01)
2. [GP-0.6.2-eq:12.24](https://graypaper.fluffylabs.dev/#/5f542d7/17db0317db03)
3. [GP-0.6.2-eq:12.27](https://graypaper.fluffylabs.dev/#/5f542d7/176304176304)