### PR TITLE
missing update l to y in seL

### DIFF
--- a/text/serialization.tex
+++ b/text/serialization.tex
@@ -140,7 +140,7 @@ A block $\mathbf{B}$ is serialized as a tuple of its elements in regular order, 
   \se_U(\mathbf{H}) &= \se(\mathbf{H}_p,\mathbf{H}_r,\mathbf{H}_x)\concat\se_4(\mathbf{H}_t)\concat\se(\maybe{\mathbf{H}_e},\maybe{\mathbf{H}_w},\var{\mathbf{H}_o},\se_2(\mathbf{H}_i),\mathbf{H}_v)\\
   \se(x \in \mathbb{X}) &\equiv \se(x_a, x_s, x_b, x_l)\concat\se_4(x_t)\concat\se(\var{x_\mathbf{p}})\\
   \se(x \in \mathbb{S}) &\equiv \se(x_h) \concat \se_4(x_l)\concat\se(x_u, x_e) \concat \se_2(x_n) \\
-  \se(x \in \mathbb{L}) &\equiv \se_4(x_s)\concat\se(x_c, x_l)\concat\se_8(x_g)\concat\se(O(x_\wl¬data))\\
+  \se(x \in \mathbb{L}) &\equiv \se_4(x_s)\concat\se(x_c, x_y)\concat\se_8(x_g)\concat\se(O(x_\wl¬data))\\
   \se(x \in \mathbb{W}) &\equiv \se(x_s, x_x, x_c, x_a, \var{x_\wr¬authoutput}, \var{x_\mathbf{l}}, \var{x_\wr¬results}) \\
   \se(x \in \mathbb{P}) &\equiv \se(\var{x_\wp¬authtoken}, \se_4(x_\wp¬authcodehost), x_\wp¬authcodehash, \var{x_\wp¬authparam}, x_\wp¬context, \var{x_\wp¬workitems}) \\
   % TODO: \se_4(i) should be just \se(i), but we should wait for this to be written.


### PR DESCRIPTION
In the v0.6.3, 
![image](https://github.com/user-attachments/assets/25f2d5c0-ac9f-4ab9-a194-ba6fe2e7ab5c)
But missing update $l$ to $y$ in serialization section
![image](https://github.com/user-attachments/assets/aa8b947a-db6b-4f60-9cc9-e85006bcbbc1)
