### PR TITLE
Updated refs to synchronous entanglements

### DIFF
--- a/text/overview.tex
+++ b/text/overview.tex
@@ -55,16 +55,16 @@ Much as in the \emph{YP}, we specify $\Upsilon$ as the implication of formulatin
   \psi' &\prec (\xtdisputes, \psi) \\
   \rho^\dagger &\prec (\xtdisputes, \rho) \label{eq:rhodagger} \\
   \rho^\ddagger &\prec (\xtassurances, \rho^\dagger) \label{eq:rhoddagger} \\
-  \rho' &\prec (\xtguarantees, \rho^\ddagger, \kappa, \tau') \\
+  \rho' &\prec (\xtguarantees, \rho^\ddagger, \kappa, \tau') \label{eq:rhoprime} \\
   \mathbf{W}^* &\prec (\xtassurances, \rho') \\
-  (\ready', \accumulated', \accountspostxfer, \chi', \iota', \varphi', \beefycommitmap) &\prec (\mathbf{W}^*, \ready, \accumulated, \accountspre, \chi, \iota, \varphi, \tau, \tau') \\
-  \beta' &\prec (\mathbf{H}, \xtguarantees, \beta^\dagger, \beefycommitmap) \\
+  (\ready', \accumulated', \accountspostxfer, \chi', \iota', \varphi', \beefycommitmap) &\prec (\mathbf{W}^*, \ready, \accumulated, \accountspre, \chi, \iota, \varphi, \tau, \tau') \label{eq:accountspostxfer} \\
+  \beta' &\prec (\mathbf{H}, \xtguarantees, \beta^\dagger, \beefycommitmap) \label{eq:betaprime} \\
   \accountspostpreimage &\prec (\xtpreimages, \accountspostxfer, \tau') \label{eq:accountspostpreimage} \\
   \alpha' &\prec (\mathbf{H}, \xtguarantees, \varphi', \alpha) \\
   \pi' &\prec (\xtguarantees, \xtpreimages, \xtassurances, \xttickets, \tau, \kappa', \pi, \mathbf{H})\!\!\!\!\!\!\!\!
 \end{align}
 
-The only synchronous entanglements are visible through the intermediate components superscripted with a dagger and defined in equations \ref{eq:betadagger}, \ref{eq:accountspostpreimage} and \ref{eq:rhoddagger}. The latter two mark a merge and join in the dependency graph and, concretely, imply that the availability extrinsic may be fully processed and accumulation of work happen before the preimage lookup extrinsic is folded into state.
+The only synchronous entanglements are visible through the intermediate components superscripted with a dagger and defined in equations \ref{eq:betadagger}, \ref{eq:rhodagger}, \ref{eq:rhoddagger}, \ref{eq:rhoprime}, \ref{eq:accountspostxfer}, \ref{eq:betaprime} and \ref{eq:accountspostpreimage}. The latter two mark a merge and join in the dependency graph and, concretely, imply that the availability extrinsic may be fully processed and accumulation of work happen before the preimage lookup extrinsic is folded into state.
 
 \subsection{Which History?}
 


### PR DESCRIPTION
Added all references to synchronous entanglements based on the text context, instead of only some as before. Also sorted them in ascending order.