### PR TITLE
Refine Bandersnatch-VRF section

### DIFF
--- a/biblio.bib
+++ b/biblio.bib
@@ -301,7 +301,7 @@
   author          = {Seyed Hosseini and Davide Galassi},
   year            = {2024},
   url = {https://github.com/davxy/bandersnatch-vrfs-spec/blob/main/specification.pdf},
-  note = {Fetched 4th April, 2024}
+  note = {Fetched 6th March, 2025}
 }
 
 @article{ethereum2024sigital,

--- a/biblio.bib
+++ b/biblio.bib
@@ -301,7 +301,7 @@
   author          = {Seyed Hosseini and Davide Galassi},
   year            = {2024},
   url = {https://github.com/davxy/bandersnatch-vrfs-spec/blob/main/specification.pdf},
-  note = {Fetched 6th March, 2025}
+  note = {Fetched 10th March, 2025}
 }
 
 @article{ethereum2024sigital,

--- a/text/bandersnatch.tex
+++ b/text/bandersnatch.tex
@@ -6,7 +6,7 @@ The singly-contextualized Bandersnatch Schnorr-like signatures $\bandersig{k}{c}
 
 \begin{align}
   \bandersig{k \in \H_B}{c \in \H}{m \in \Y} \subset \Y_{96} &\equiv \{ x \mid x \in \Y_{96}, \text{verify}(k, c, m, x) = \top \}  \\
-  \banderout{s \in \bandersig{k}{c}{m}} \in \H &\equiv \text{output}(x \mid x \in \bandersig{k}{c}{m})
+  \banderout{s \in \bandersig{k}{c}{m}} \in \H &\equiv \text{output}(x \mid x \in \bandersig{k}{c}{m})_{\dots32}
 \end{align}
 
 The singly-contextualized Bandersnatch Ring\textsc{vrf} proofs $\bandersnatch{r}{c}{m}$ are a zk-\textsc{snark}-enabled analogue utilizing the Pedersen \textsc{vrf}, also defined by \cite{hosseini2024bandersnatch} and further detailed by \cite{cryptoeprint:2023/002}.
@@ -14,7 +14,7 @@ The singly-contextualized Bandersnatch Ring\textsc{vrf} proofs $\bandersnatch{r}
 \begin{align}
   \mathcal{O}(\seq{\H_B}) \in \Y_R &\equiv \text{KZG\_commitment}(\seq{\H_B})  \\
   \bandersnatch{r \in \Y_R}{c \in \H}{m \in \Y} \subset \Y_{784} &\equiv \{ x \mid x \in \Y_{784}, \text{verify}(r, c, m, x) = \top \}  \\
-  \banderout{p \in \bandersnatch{r}{c}{m}} \in \H &\equiv \text{output}(x \mid x \in \bandersnatch{r}{c}{m})
+  \banderout{p \in \bandersnatch{r}{c}{m}} \in \H &\equiv \text{output}(x \mid x \in \bandersnatch{r}{c}{m})_{\dots32}
 \end{align}
 
 Note that in the case a key $\H_B$ has no corresponding Bandersnatch point when constructing the ring, then the Bandersnatch \emph{padding point} as stated by \cite{hosseini2024bandersnatch} should be substituted.

--- a/text/bandersnatch.tex
+++ b/text/bandersnatch.tex
@@ -1,20 +1,20 @@
-\section{Bandersnatch Ring VRF}\label{sec:bandersnatch}
+\section{Bandersnatch VRF}\label{sec:bandersnatch}
 
 The Bandersnatch curve is defined by \cite{cryptoeprint:2021/1152}.
 
-The singly-contextualized Bandersnatch Schnorr-like signatures $\bandersig{k}{c}{m}$ are defined as a formulation under the \emph{ietf} \textsc{vrf} template specified by \cite{hosseini2024bandersnatch} (as IETF VRF) and further detailed by \cite{rfc9381}.
+The singly-contextualized Bandersnatch Schnorr-like signatures $\bandersig{k}{c}{m}$ are defined as a formulation under the \emph{IETF} \textsc{vrf} template specified by \cite{hosseini2024bandersnatch} (as IETF VRF) and further detailed by \cite{rfc9381}.
 
 \begin{align}
-  \bandersig{k \in \H_B}{c \in \H}{m \in \Y} \subset \Y_{96} &\equiv \{ x \mid x \in \Y_{96}, \text{verify}(k, c, m, \text{decode}(x_{\dots32}), \text{decode}(x_{32\dots})) = \top \}  \\
-  \banderout{s \in \bandersig{k}{c}{m}} \in \H &\equiv \text{hashed\_output}(\text{decode}(x_{\dots32}) \mid x \in \bandersig{k}{c}{m})
+  \bandersig{k \in \H_B}{c \in \H}{m \in \Y} \subset \Y_{96} &\equiv \{ x \mid x \in \Y_{96}, \text{verify}(k, c, m, x) = \top \}  \\
+  \banderout{s \in \bandersig{k}{c}{m}} \in \H &\equiv \text{output}(x \mid x \in \bandersig{k}{c}{m})
 \end{align}
 
 The singly-contextualized Bandersnatch Ring\textsc{vrf} proofs $\bandersnatch{r}{c}{m}$ are a zk-\textsc{snark}-enabled analogue utilizing the Pedersen \textsc{vrf}, also defined by \cite{hosseini2024bandersnatch} and further detailed by \cite{cryptoeprint:2023/002}.
 
 \begin{align}
   \mathcal{O}(\seq{\H_B}) \in \Y_R &\equiv \text{KZG\_commitment}(\seq{\H_B})  \\
-  \bandersnatch{r \in \Y_R}{c \in \H}{m \in \Y} \subset \Y_{784} &\equiv \{ x \mid x \in \Y_{784}, \text{verify}(r, c, m, \text{decode}(x_{\dots32}), \text{decode}(x_{32\dots})) = \top \}  \\
-  \banderout{p \in \bandersnatch{r}{c}{m}} \in \H &\equiv \text{hashed\_output}(\text{decode}(x_{\dots32}) \mid x \in \bandersnatch{r}{c}{m})
+  \bandersnatch{r \in \Y_R}{c \in \H}{m \in \Y} \subset \Y_{784} &\equiv \{ x \mid x \in \Y_{784}, \text{verify}(r, c, m, x) = \top \}  \\
+  \banderout{p \in \bandersnatch{r}{c}{m}} \in \H &\equiv \text{output}(x \mid x \in \bandersnatch{r}{c}{m})
 \end{align}
 
 Note that in the case a key $\H_B$ has no corresponding Bandersnatch point when constructing the ring, then the Bandersnatch \emph{padding point} as stated by \cite{hosseini2024bandersnatch} should be substituted.

--- a/text/bandersnatch.tex
+++ b/text/bandersnatch.tex
@@ -12,7 +12,7 @@ The singly-contextualized Bandersnatch Schnorr-like signatures $\bandersig{k}{c}
 The singly-contextualized Bandersnatch Ring\textsc{vrf} proofs $\bandersnatch{r}{c}{m}$ are a zk-\textsc{snark}-enabled analogue utilizing the Pedersen \textsc{vrf}, also defined by \cite{hosseini2024bandersnatch} and further detailed by \cite{cryptoeprint:2023/002}.
 
 \begin{align}
-  \mathcal{O}(\seq{\H_B}) \in \Y_R &\equiv \text{KZG\_commitment}(\seq{\H_B})  \\
+  \mathcal{O}(\seq{\H_B}) \in \Y_R &\equiv \text{commit}(\seq{\H_B})  \\
   \bandersnatch{r \in \Y_R}{c \in \H}{m \in \Y} \subset \Y_{784} &\equiv \{ x \mid x \in \Y_{784}, \text{verify}(r, c, m, x) = \top \}  \\
   \banderout{p \in \bandersnatch{r}{c}{m}} \in \H &\equiv \text{output}(x \mid x \in \bandersnatch{r}{c}{m})_{\dots32}
 \end{align}


### PR DESCRIPTION
**Specification Reference Update**  
 - The latest specification introduces breaking changes, rendering it incompatible with the initial version (e.g. base point changes, ring-proof now works with TE points).  
 - Test vectors in the document have been revised, and the example sources now align with the [published reference implementation](https://crates.io/crates/ark-ec-vrfs).  
    
**Bandersnatch VRF Section Update**  
- The  *verify* and *output* interface has been simplified by consolidating the separate `proof` and `output` parameters into a single proof parameter, which remains opaque from the GP perspective.  
- Instructions for interpreting this *proof* param are outlined in the Bandersnatch VRF spec.
- Polynomial commitment scheme is defined in Bandersnatch VRF spec