### PR TITLE
Accumulation: parallelized accumulation function: switch priviliged services indices

### DIFF
--- a/text/accumulation.tex
+++ b/text/accumulation.tex
@@ -143,8 +143,8 @@ We come to define the parallelized accumulation function $\Delta_*$ which, with 
       \mathbf{t} &= [\Delta_1(\mathbf{o}, \mathbf{w}, \mathbf{f}, s)_\mathbf{t} \mid s \orderedin \mathbf{s}] \\
       &(\mathbf{d}, \mathbf{i}, \mathbf{q}, (m, a, v, \mathbf{z})) = \mathbf{o} \\
       \mathbf{x}' &= (\Delta_1(\mathbf{o}, \mathbf{w}, \mathbf{f}, m)_\mathbf{o})_\mathbf{x} \\
-      \mathbf{i}' &= (\Delta_1(\mathbf{o}, \mathbf{w}, \mathbf{f}, a)_\mathbf{o})_\mathbf{i} \\
-      \mathbf{q}' &= (\Delta_1(\mathbf{o}, \mathbf{w}, \mathbf{f}, v)_\mathbf{o})_\mathbf{q} \\
+      \mathbf{i}' &= (\Delta_1(\mathbf{o}, \mathbf{w}, \mathbf{f}, v)_\mathbf{o})_\mathbf{i} \\
+      \mathbf{q}' &= (\Delta_1(\mathbf{o}, \mathbf{w}, \mathbf{f}, a)_\mathbf{o})_\mathbf{q} \\
       \mathbf{n} &= \bigcup_{s \in \mathbf{s}}(\{ (\Delta_1(\mathbf{o}, \mathbf{w}, \mathbf{f}, s)_\mathbf{o})_\mathbf{d} \setminus \keys{\mathbf{d} \setminus \{s\}} \}) \\
       \mathbf{m} &= \bigcup_{s \in \mathbf{s}}(\keys{\mathbf{d}} \setminus \keys{(\Delta_1(\mathbf{o}, \mathbf{w}, \mathbf{f}, s)_\mathbf{o})_\mathbf{d}})
     \end{aligned}


### PR DESCRIPTION
In Accumulation parallelized accumulation function:
the service `a` should transition **q**
and the service `v` should transition **i**

quoting  from [9.4](https://graypaper.fluffylabs.dev/#/5f542d7/116f01116f01?v=0.6.3):

_χa and χv , are each the indices of services able to alter φ and ι from block to block._

