### PR TITLE
Assurances are checked with the prior validator set

### DIFF
--- a/text/reporting_assurance.tex
+++ b/text/reporting_assurance.tex
@@ -120,7 +120,7 @@ The assurances must all be anchored on the parent and ordered by validator index
 
 The signature must be one whose public key is that of the validator assuring and whose message is the serialization of the parent hash $\mathbf{H}_p$ and the aforementioned bitstring:
 \begin{align}
-  &\forall a \in \xtassurances : a_s \in \sig{\kappa'[a_v]_e}{\mathsf{X}_A\frown \mathcal{H}(\se(\mathbf{H}_p, a_f))} \\
+  &\forall a \in \xtassurances : a_s \in \sig{\kappa[a_v]_e}{\mathsf{X}_A\frown \mathcal{H}(\se(\mathbf{H}_p, a_f))} \\
   &\mathsf{X}_A \equiv \token{\$jam\_available}
 \end{align}
 


### PR DESCRIPTION
Assurances are signed statements by validators confirming they have received all the necessary data. Since these statements are signed before the current block is created, the signatures should be validated against the validator set that was active at the time of signing, which is the prior validator set (kappa).
