### PR TITLE
Include ed25519 keys in the epoch marker

### DIFF
--- a/text/header.tex
+++ b/text/header.tex
@@ -51,7 +51,7 @@ All blocks have an associated public key to identify the author of the block. We
 
 If not $\none$, then the epoch marker specifies key and entropy relevant to the following epoch in case the ticket contest does not complete adequately (a very much unexpected eventuality). Similarly, the winning-tickets marker, if not $\none$, provides the series of 600 slot sealing ``tickets'' for the next epoch (see the next section). Finally, the offenders marker is the sequence of Ed25519 keys of newly misbehaving validators, to be fully explained in section \ref{sec:disputes}. Formally:
 \begin{equation}
-  \mathbf{H}_e \in \tuple{\H\ts\H\ts\lseq\H_B\rseq_{\mathsf{V}}}\bm{?}\,,\quad
+  \mathbf{H}_e \in \tuple{\H\ts\H\ts\lseq\tup{\H_B, \H_E}\rseq_{\mathsf{V}}}\bm{?}\,,\quad
   \mathbf{H}_w \in \seq{\mathbb{C}} _{\mathsf{E}}\bm{?}\,,\quad
   \mathbf{H}_o \in \seq{\H_E}
 \end{equation}

--- a/text/safrole.tex
+++ b/text/safrole.tex
@@ -211,10 +211,10 @@ Finally, $F$ is the fallback key sequence function which selects an epoch's wort
 
 The epoch and winning-tickets markers are information placed in the header in order to minimize data transfer necessary to determine the validator keys associated with any given epoch. They are particularly useful to nodes which do not synchronize the entire state for any given block since they facilitate the secure tracking of changes to the validator key sets using only the chain of headers.
 
-As mentioned earlier, the header's epoch marker $\mathbf{H}_e$ is either empty or, if the block is the first in a new epoch, then a tuple of the next and current epoch randomness, along with a sequence of Bandersnatch keys defining the Bandersnatch validator keys ($k_b$) beginning in the next epoch. Formally:
+As mentioned earlier, the header's epoch marker $\mathbf{H}_e$ is either empty or, if the block is the first in a new epoch, then a tuple of the next and current epoch randomness, along with a sequence of tuples containing both Bandersnatch keys and Ed25519 keys for each validator defining the validator keys beginning in the next epoch. Formally:
 \begin{align}\label{eq:epochmarker}
   \mathbf{H}_e &\equiv \begin{cases}
-    ( \eta_0, \eta_1, [ k_b \mid k \orderedin \gamma'_\mathbf{k} ] )\qquad\qquad &\when e' > e \\
+    ( \eta_0, \eta_1, [ \tup{k_b, k_e} \mid k \orderedin \gamma'_\mathbf{k} ] )\qquad\qquad &\when e' > e \\
     \none & \otherwise
   \end{cases}
 \end{align}


### PR DESCRIPTION
This is useful for GRANDPA and calculating assurer sets for past epochs.


<img width="409" alt="image" src="https://github.com/user-attachments/assets/a27bf00e-4c28-41a8-8b3a-ba70a1c6203f" />


<img width="471" alt="image" src="https://github.com/user-attachments/assets/c10bd81f-5447-4be1-a83c-56367749eaf5" />
