### PR TITLE
[hotfix] info host function should return storage octets metadata

### DIFF
--- a/text/pvm_invocations.tex
+++ b/text/pvm_invocations.tex
@@ -363,7 +363,7 @@ Other than the gas-counter which is explicitly defined, elements of \textsc{pvm}
     \end{cases} \\
     \using o &= \registers_8 \\
     \using \mathbf{m} &= \begin{cases}
-      \mathcal{E}(\mathbf{t}_c, \mathbf{t}_b, \mathbf{t}_t, \mathbf{t}_g, \mathbf{t}_m, \mathbf{t}_l, \mathbf{t}_i) &\when \mathbf{t} \ne \none \\
+      \mathcal{E}(\mathbf{t}_c, \mathbf{t}_b, \mathbf{t}_t, \mathbf{t}_g, \mathbf{t}_m, \mathbf{t}_o, \mathbf{t}_i) &\when \mathbf{t} \ne \none \\
       \none &\otherwise
     \end{cases} \\
     \forall i \in \N_{|\mathbf{m}|} : \memory'_{o + i} &\equiv \begin{cases}


### PR DESCRIPTION
as discussed [in the GP matrix channel](https://matrix.to/#/!ddsEwXlCWnreEGuqXZ:polkadot.io/$z-b5WmQo9nQY3anTn7YC2orZJgCgIZMtomwGCNzHB54?via=polkadot.io&via=matrix.org&via=parity.io)

The INFO host function should return the storage octets here