### PR TITLE
Change B_L to B_O

### DIFF
--- a/text/accounts.tex
+++ b/text/accounts.tex
@@ -136,7 +136,7 @@ We may then define a second dependent term $t$, the minimum, or \emph{threshold}
     a_i \in \N_{2^{32}} &\equiv 2\cdot|\,a_\mathbf{l}\,| + |\,a_\mathbf{s}\,| \\
     a_o \in \N_{2^{64}} &\equiv \sum\limits_{\,(h, z) \in \keys{a_\mathbf{l}}\,} 81 + z \\
     &\phantom{\equiv} + \sum\limits_{x \in \mathcal{V}(a_\mathbf{s})} 32 + |x| \\
-    a_t \in \N_B &\equiv \mathsf{B}_S + \mathsf{B}_I \cdot a_i + \mathsf{B}_L \cdot a_o
+    a_t \in \N_B &\equiv \mathsf{B}_S + \mathsf{B}_I \cdot a_i + \mathsf{B}_O \cdot a_o
   \end{cases}
 \end{align}
 

--- a/text/definitions.tex
+++ b/text/definitions.tex
@@ -258,7 +258,7 @@ Here, the prime annotation indicates posterior state. Individual components may 
 \begin{description}
   \item[$\mathsf{A} = 8$] The period, in seconds, between audit tranches.
   \item[$\mathsf{B}_I = 10$] The additional minimum balance required per item of elective service state.
-  \item[$\mathsf{B}_L = 1$] The additional minimum balance required per octet of elective service state.
+  \item[$\mathsf{B}_O = 1$] The additional minimum balance required per octet of elective service state.
   \item[$\mathsf{B}_S = 100$] The basic minimum balance which all services require.
   \item[$\mathsf{C} = 341$] The total number of cores.
   \item[$\mathsf{D} = 28,800$] The period in timeslots after which an unreferenced preimage may be expunged.

--- a/text/overview.tex
+++ b/text/overview.tex
@@ -115,7 +115,7 @@ We further presume that a number of constant \emph{prices} stated in terms of to
 
 \begin{description}\label{eq:prices}
   \item[$\mathsf{B}_I$] the additional minimum balance implied for a single item within a mapping.
-  \item[$\mathsf{B}_L$] the additional minimum balance implied for a single octet of data within a mapping.
+  \item[$\mathsf{B}_O$] the additional minimum balance implied for a single octet of data within a mapping.
   \item[$\mathsf{B}_S$] the minimum balance implied for a service.
 \end{description}
 


### PR DESCRIPTION
Renamed the constant from `B_L` to `B_O`.
`B_O` implies 'Octet'