### PR TITLE
WPs&WRs: SR lookup key should be work package hash

### DIFF
--- a/text/work_packages_and_reports.tex
+++ b/text/work_packages_and_reports.tex
@@ -179,7 +179,7 @@ Formally:
 
 Where:
 \begin{align*}
-  \keys{\mathbf{l}} \equiv \,&\{ h \mid w \in p_\mathbf{w}, (h^\boxplus, n) \in w_\mathbf{i} \} \ ,\quad|\mathbf{l}| \le 8\\
+  \keys{\mathbf{l}} \equiv \,&\{ h^\boxplus \mid w \in p_\mathbf{w}, (h^\boxplus, n) \in w_\mathbf{i} \} \ ,\quad|\mathbf{l}| \le 8\\
   \mathbf{o} = \,&\Psi_I(\wpX, c) \\
   (\mathbf{r}, \overline{\mathbf{e}}) = \,&\transpose[
     (\itemtoresult(\wpX_\wp¬workitems[j], r), \mathbf{e})
@@ -206,7 +206,7 @@ We immediately define the segment-root lookup function $L$, dependent on this di
 \begin{equation}
   L(r \in \H\cup\H^\boxplus) \equiv \begin{cases}
     r &\when r \in \H \\
-    \mathbf{l}[h] &\when \exists h \in \H: r = h^\boxplus
+    \mathbf{l}[r] &\when \exists h \in \H: r = h^\boxplus
   \end{cases}
 \end{equation}
 


### PR DESCRIPTION
SR lookup keys should be work package hash (h with boxplus tag), not the SR.