### PR TITLE
fix: use pi_V instead of pi_C in serialization

### DIFF
--- a/text/merklization.tex
+++ b/text/merklization.tex
@@ -36,7 +36,7 @@ The state serialization is then defined as the dictionary built from the amalgam
     &&C(10) &\mapsto \se([\maybe{(w, \se_4(t))} \mid (w, t) \orderedin \rho]) \;, \\
     &&C(11) &\mapsto \se_4(\tau) \;, \\
     &&C(12) &\mapsto \se_4(\chi_m, \chi_a, \chi_v) \concat \se(\chi_\mathbf{g}) \;, \\
-    &&C(13) &\mapsto \se(\se^\#_4(\pi_C), \se^\#_4(\pi_L), \pi_C, \pi_S) \;, \\
+    &&C(13) &\mapsto \se(\se^\#_4(\pi_V), \se^\#_4(\pi_L), \pi_C, \pi_S) \;, \\
     &&C(14) &\mapsto \se([\var{(\mathbf{w}, \var{\mathbf{d}})} \mid (\mathbf{w}, \mathbf{d}) \orderedin \mathbf{i} \mid \mathbf{i} \orderedin \ready]) \;, \\
     &&C(15) &\mapsto \se([\var{\mathbf{i}} \mid \mathbf{i} \orderedin \accumulated]) \;, \\
     \forall (s \mapsto \mathbf{a}) \in \delta: &&C(255, s) &\mapsto \mathbf{a}_c \concat \se_8(\mathbf{a}_b, \mathbf{a}_g, \mathbf{a}_m, \mathbf{a}_o) \concat \se_4(\mathbf{a}_i) \;, \\


### PR DESCRIPTION
The C(13) in the statistic serialization (Appendix D. State Merklization) incorrectly used pi_C in the first position. This commit updates it to pi_V to ensure the correct variable is used in the formula. (v0.6.4)

![image](https://github.com/user-attachments/assets/f2791782-9288-4fbb-9fac-dc4ec31e72d2)
