### PR TITLE
Remove unnecessary serialization before hashing

### DIFF
--- a/text/reporting_assurance.tex
+++ b/text/reporting_assurance.tex
@@ -235,7 +235,7 @@ The signature must be one whose public key is that of the validator identified i
       \forall (v, s) &\in a
     \end{aligned}
       : \left\{\,\begin{aligned}
-        &s \in \sig{(\mathbf{k}_v)_e}{\mathsf{X}_G\frown\mathcal{H}(\se(w))}\\
+        &s \in \sig{(\mathbf{k}_v)_e}{\mathsf{X}_G\frown\mathcal{H}(w)}\\
         &\mathbf{c}_v = w_c \wedge \mathsf{R}(\floor{\nicefrac{\tau'}{\mathsf{R}}} - 1) \le t \le \tau'\\
       \end{aligned}\right.\\
       &k \in \mathbf{R} \Leftrightarrow \exists (w, t, a) \in \xtguarantees, \exists (v, s) \in a: k = (\mathbf{k}_v)_e\\


### PR DESCRIPTION
My initial change was to add explicit serialization before hashing the work report in equation 5.6 (#295). The intention was to make this consistent with how it was done in equation 11.26. But given the mention of section 3.8.1, it makes sense that this should also not explicitly serialize because it's not ambiguous. (also I should have noticed that everywhere else is just H(w) , it's just that 11.26 was the first example I came across :))