### PR TITLE
Accounts: use constant `D` in historical lookup function description

### DIFF
--- a/text/accounts.tex
+++ b/text/accounts.tex
@@ -72,7 +72,7 @@ Restated, we must be able to define some \emph{historical} lookup function $\Lam
 \begin{equation}
 \begin{aligned}
   \Lambda\colon \left\{\ \begin{aligned}
-    (\mathbb{A}, \N_{\mathbf{H}_t - C_D\dots\mathbf{H}_t}, \mathbb{H}) &\to \mathbb{Y}\bm{?} \\
+    (\mathbb{A}, \N_{\mathbf{H}_t - \mathsf{D}\dots\mathbf{H}_t}, \mathbb{H}) &\to \mathbb{Y}\bm{?} \\
     (\mathbf{a}, t, \mathcal{H}(\mathbf{p})) &\mapsto v : v \in \{ \mathbf{p}, \none \}
   \end{aligned}\right.
 \end{aligned}


### PR DESCRIPTION
This PR corrects a typo in the historical lookup function, updating `C_D` to `D` as mentioned earlier in the element channel.