### PR TITLE
Add missing void service/gas pair sequence in the outer accumulation function

### DIFF
--- a/text/accumulation.tex
+++ b/text/accumulation.tex
@@ -120,7 +120,7 @@ We define the outer accumulation function $\Delta_+$ which transforms a gas-limi
   \Delta_+\colon\left\{\begin{aligned}
     &(\N_G, \seq{\mathbb{W}}, \partialstate, \dict{\N_S}{\N_G}) \to (\N, \partialstate, \defxfers, \servouts, \gasused) \\
     &(g, \mathbf{w}, \mathbf{o}, \mathbf{f}) \!\mapsto\! \begin{cases}
-      (0, \mathbf{o}, [], \{\}) &
+      (0, \mathbf{o}, [], \{\}, []) &
         \when i = 0 \\
       (i + j, \mathbf{o}', \mathbf{t}^* \!\!\concat \mathbf{t}, \mathbf{b}^* \!\cup \mathbf{b}, \mathbf{u}^* \!\!\concat \mathbf{u})\!\!\!\! &
         \text{o/w}\!\!\!\!\!\!\!\! \\


### PR DESCRIPTION
Void sequence `U ≡ ⟦ (NS, NG) ⟧` is missing in the outer accumulation function when `i = 0`