### PR TITLE
Serializiation: Operand tuples: remove variable size

### DIFF
--- a/text/serialization.tex
+++ b/text/serialization.tex
@@ -158,7 +158,7 @@ A block $\mathbf{B}$ is serialized as a tuple of its elements in regular order, 
   \se(x \in \defxfer) &\equiv \se(\se_4(x_s), \se_4(x_d), \se_8(x_a), \se(x_m), \se_8(x_g)) \\
   \se(x \in \mathbb{O}) &\equiv \se(x_h, x_e, x_a, \var{x_\mathbf{o}}, x_y, O(x_\mathbf{d})) \\
   O(o \in \mathbb{J} \cup \Y) &\equiv \begin{cases}
-    (0, \var{o}) &\when o \in \Y \\
+    (0, o) &\when o \in \Y \\
     1 &\when o = \infty \\
     2 &\when o = \panic \\
     3 &\when o = \badexports \\


### PR DESCRIPTION
Variable size is not needed for the encoding of the **d** element as it is an octet sequence and fully determined by the `0` prefix