### PR TITLE
fix: work item resultant datum d typo

### DIFF
--- a/text/work_packages_and_reports.tex
+++ b/text/work_packages_and_reports.tex
@@ -121,7 +121,7 @@ We limit the sums of each of the two gas limits to be at most the maximum gas al
 
 %The implication of equation \ref{eq:checkextractsize} is that we have access to the preimage of all extrinsic data. For guaranteeing, this implies the work-package author probably submits the preimages alongside the work-package itself. For auditing, the extrinsic preimages may be reconstructed in the same manner as the work-package. Both are described later.
 
-Given the resultant datum $d$ of some work-item, we define the item-to-result function $\itemtoresult$ as:
+Given the resultant datum $\wl¬data$ of some work-item, we define the item-to-result function $\itemtoresult$ as:
 \begin{equation}
   \itemtoresult\colon\left\{\begin{aligned}
     (\mathbb{I}, \Y \cup \mathbb{J}, \N_G) &\to \mathbb{L}\\


### PR DESCRIPTION
The work item resultant datum d has a typo, should be  \mathbf{d} according to function C below

https://graypaper.fluffylabs.dev/#/68eaa1f/1a45011a4501?v=0.6.4