### PR TITLE
work report description

### DIFF
--- a/text/reporting_assurance.tex
+++ b/text/reporting_assurance.tex
@@ -21,7 +21,7 @@ The state of the reporting and availability portion of the protocol is largely c
 As usual, intermediate and posterior values ($\rho^\dagger$, $\rho^\ddagger$, $\rho'$) are held under the same constraints as the prior value.
 
 \subsubsection{Work Report}\label{sec:workreport}
-A work-report, of the set $\mathbb{W}$, is defined as a tuple of the work-package specification $s$, the refinement context $x$, and the core-index (\ie on which the work is done) as well as the authorizer hash $a$ and output $\wr¬authoutput$, a segment-root lookup dictionary $\wr¬srlookup$, the results of the evaluation of each of the items in the package $\wr¬results$, and finally the gas consumed during refinement. Formally:
+A work-report, of the set $\mathbb{W}$, is defined as a tuple of the work-package specification $s$, the refinement context $x$, and the core-index (\ie on which the work is done) as well as the authorizer hash $a$ and output $\wr¬authoutput$, a segment-root lookup dictionary $\wr¬srlookup$, the results of the evaluation of each of the items in the package $\wr¬results$, and finally the gas consumed during the is-authorized invocation. Formally:
 \begin{equation}\label{eq:workreport}
 \mathbb{W} \equiv \tuple{
   \begin{aligned}


### PR DESCRIPTION
recently there was a gas-related field added to the work report tuple

this pr updates the tuple description paragraph to include this field. **I also removed the results length description for sake of brevity/cleanliness, since it can be pretty easily gathered from the tuple field subscript itself that the length is 1..I** Happy to adjust here if needed.

*I'm assuming this newly-added field represents the gas consumed during refinement, based on the other changes from https://github.com/gavofyork/graypaper/pull/285*