### PR TITLE
Remove unambigious serialization

### DIFF
--- a/text/header.tex
+++ b/text/header.tex
@@ -24,7 +24,7 @@ The extrinsic hash is a Merkle commitment to the block's extrinsic data, taking 
   \mathbf{H}_x &\in \H \ ,\quad
   \mathbf{H}_x \equiv \mathcal{H}(\se(\mathcal{H}^\#(\mathbf{a}))) \\
   \where \mathbf{a} &= [\se_T(\xttickets), \se_P(\xtpreimages), \mathbf{g}, \se_A(\xtassurances), \se_D(\xtdisputes)] \\
-  \also \mathbf{g} &= \se(\var{[\se(\mathcal{H}(w), \se_4(t), \var{a}) \mid (w, t, a) \orderedin \xtguarantees]})
+  \also \mathbf{g} &= \se(\var{[(\mathcal{H}(w), \se_4(t), \var{a}) \mid (w, t, a) \orderedin \xtguarantees]})
 \end{align}
 
 A block may only be regarded as valid once the time-slot index $\mathbf{H}_t$ is in the past. It is always strictly greater than that of its parent. Formally:


### PR DESCRIPTION
I might be missing something here but the explicit serialization around the tuple seems redundant and removing it seems more in line with similar equations for the other extrinsics in the appendix.