### PR TITLE
WPs&WRs: Fix typo in WP gas limit constraints

### DIFF
--- a/text/work_packages_and_reports.tex
+++ b/text/work_packages_and_reports.tex
@@ -116,7 +116,7 @@ We limit the sums of each of the two gas limits to be at most the maximum gas al
   \forall \wpX \in \mathbb{P}:\ \;
     \sum_{\wiX \in \wpX_\wp¬workitems}(\wiX_a) < \mathsf{G}_A
   \quad\wedge\ \;
-    \sum_{\wiX \in \wpX_\wp¬workitems}(\wiX_r) < \mathsf{G}_R
+    \sum_{\wiX \in \wpX_\wp¬workitems}(\wiX_g) < \mathsf{G}_R
 \end{equation}
 
 %The implication of equation \ref{eq:checkextractsize} is that we have access to the preimage of all extrinsic data. For guaranteeing, this implies the work-package author probably submits the preimages alongside the work-package itself. For auditing, the extrinsic preimages may be reconstructed in the same manner as the work-package. Both are described later.


### PR DESCRIPTION
In the work package gas limit constraints, work item refine gas limit should be `g`, not `r`.