### PR TITLE
Fix typos in preimage integration function

### DIFF
--- a/text/accumulation.tex
+++ b/text/accumulation.tex
@@ -163,8 +163,8 @@ And $\fnprovide$ is the preimage integration function, which transforms a dictio
     &\quad\forall \tup{s, \mathbf{i}} \in \mathbf{p},\;
       s \in \keys{\mathbf{d}},\;
       \mathbf{d}[s]_\mathbf{l}[\hash(\mathbf{i}), |\mathbf{i}|] = \sq{}:\\
-    &\qquad \mathbf{d}'[s]_\mathbf{l}[\hash(\mathbf{i}), |\mathbf{i}|] = \tau'\\
-    &\qquad \mathbf{d}'[s]_\mathbf{p}[\hash{\mathbf{i}}] = \mathbf{i}
+    &\qquad \mathbf{d}'[s]_\mathbf{l}[\hash(\mathbf{i}), |\mathbf{i}|] = [\tau']\\
+    &\qquad \mathbf{d}'[s]_\mathbf{p}[\hash(\mathbf{i})] = \mathbf{i}
     %\begin{aligned}
     %  \tup{s, \mathbf{i}} \in \mathbf{p} \wedge
     %  s \in \keys{\mathbf{d}}\;\wedge& \\


### PR DESCRIPTION
Fixed typos in the new preimage integration function:
1. Updated `τ'` into `[τ']` to represent timeslot sequence.
2. Use `()` for \hash - previously the hash function didn't render correctly:
<img width="277" alt="Screenshot 2025-04-26 at 1 50 04 AM" src="https://github.com/user-attachments/assets/f04bed0f-7312-4593-b475-b66314e240e8" />
