### PR TITLE
Clarify commentary following data availability specification definition

### DIFF
--- a/text/work_packages_and_reports.tex
+++ b/text/work_packages_and_reports.tex
@@ -257,7 +257,7 @@ We may then define $\wr¬avspec$ as the data availability specification of the p
   )\!\!\!\!
 \end{equation}
 
-Note that while $\importsegmentdata$ and $\justifysegmentdata$ are both formulated using the inner term $\segsX$ (all segments exported by all work-packages exporting a segment to be imported) such a vast amount of data is not generally needed as the justification can be derived through a single paged-proof. This reduces the worst case data fetching for a guarantor to two segments for every one to be imported. In the case that contiguously exported segments are imported (which we might assume is a fairly common situation), then a single proof-page should be sufficient to justify many imported segments.
+Note that while the formulations of $\importsegmentdata$ and $\justifysegmentdata$ seem to require (due to the inner term $\segsX$) all segments exported by all work-packages exporting a segment to be imported, such a vast amount of data is not generally needed. In particular, each justification can be derived through a single paged-proof. This reduces the worst case data fetching for a guarantor to two segments for every one to be imported. In the case that contiguously exported segments are imported (which we might assume is a fairly common situation), then a single proof-page should be sufficient to justify many imported segments.
 
 Also of note is the lack of length prefixes: only the Merkle paths for the justifications have a length prefix. All other sequence lengths are determinable through the work package itself.
 


### PR DESCRIPTION
The previous wording seemed to imply that `\segsX` meant "all segments exported by all work-packages exporting a segment to be imported".