### PR TITLE
PVM Invocations: Fix up program init function

### DIFF
--- a/text/pvm.tex
+++ b/text/pvm.tex
@@ -758,11 +758,11 @@ We use both values of instruction-counter for the definition of $\Psi_H$ since i
 \subsection{Standard Program Initialization}\label{sec:standardprograminit}
 The software programs which will run in each of the four instances where the \textsc{pvm} is utilized in the main document have a very typical setup pattern characteristic of an output of a compiler and linker. This means that \textsc{ram} has sections for program-specific read-only data, read-write (heap) data and the stack. An adjunct to this, very typical of our usage patterns is an extra read-only section via which invocation-specific data may be passed (\ie arguments). It thus makes sense to define this properly in a single initializer function. These sections are quantized into \emph{major zones}, and one major zone is always left unallocated between sections in order to reduce accidental overrun. Sections are padded with zeroes to the nearest \textsc{pvm} memory page boundary.
 
-We thus define the standard program code format $\mathbf{p}$, which includes not only the instructions and jump table (previously represented by the term $\mathbf{c}$), but also information on the state of the \textsc{ram} at program start. Given some $\mathbf{p}$ which is appropriately encoded together with some argument data $\mathbf{a}$, we can define program code $\mathbf{c}$, registers $\registers$ and \textsc{ram} $\mem$ through the standard initialization decoder function $Y$:
+We thus define the standard program code format $\mathbf{p}$, which includes not only the instructions and jump table (previously represented by the term $\mathbf{c}$), but also information on the state of the \textsc{ram} at program start. Given program blob $\mathbf{p}$ and argument data $\mathbf{a}$, we can decode the program code $\mathbf{c}$, registers $\registers$, and \textsc{ram} $\mem$ by invoking the standard initialization function $Y(\mathbf{p}, \mathbf{a})$:
 \begin{equation}
 Y\colon\left\{\begin{aligned}
-  \Y &\to (\Y, \regs, \ram)? \\
-  \mathbf{p} &\mapsto \begin{cases}
+  (\Y, \Y_{:\mathsf{Z}_I}) &\to (\Y, \regs, \ram)? \\
+  (\mathbf{p}, \mathbf{a}) &\mapsto \begin{cases}
     (\mathbf{c}, \registers, \mem) &\when \exists! (\mathbf{c}, \mathbf{o}, \mathbf{w}, z, s) \text{ which satisfy equation \ref{eq:conditions}}\\
     \none &\otherwise
   \end{cases}
@@ -770,7 +770,7 @@ Y\colon\left\{\begin{aligned}
 \end{equation}
 With conditions:
 \begin{align}\label{eq:conditions}
-  &\using \mathcal{E}_3(|\mathbf{o}|) \concat \mathcal{E}_3(|\mathbf{w}|) \concat \mathcal{E}_2(z) \concat \mathcal{E}_3(s) \concat \mathbf{o} \concat \mathbf{w} \concat \mathcal{E}_4(|\mathbf{c}|) \concat \mathbf{c} \concat \mathbf{a} = \mathbf{p}\\
+  &\using \mathcal{E}_3(|\mathbf{o}|) \concat \mathcal{E}_3(|\mathbf{w}|) \concat \mathcal{E}_2(z) \concat \mathcal{E}_3(s) \concat \mathbf{o} \concat \mathbf{w} \concat \mathcal{E}_4(|\mathbf{c}|) \concat \mathbf{c} = \mathbf{p}\\
   &\mathsf{Z}_Z = 2^{16}\ ,\quad\mathsf{Z}_I = 2^{24}\\
   &\using \rnp{x \in \N} \equiv \mathsf{Z}_P\left\lceil \frac{x}{\mathsf{Z}_P} \right\rceil\quad,\qquad\rnq{x \in \N} \equiv \mathsf{Z}_Z\left\lceil \frac{x}{\mathsf{Z}_Z} \right\rceil\\
   &5\mathsf{Z}_Z + \rnq{|\mathbf{o}|} + \rnq{|\mathbf{w}| + z\mathsf{Z}_P} + \rnq{s} + \mathsf{Z}_I \leq 2^{32}
@@ -828,8 +828,8 @@ The four instances where the \textsc{pvm} is utilized each expect to be able to 
       \Y, \N_R, \N_G, \Y_{:\mathsf{Z}_I}, \Omega\langle X \rangle, X
     \right) &\to (\N_G, \Y \cup \{\panic, \oog\}, X)\\
     (\mathbf{p}, \imath, \gascounter, \mathbf{a}, f, \mathbf{x}) &\mapsto \begin{cases}
-      (0, \panic, \mathbf{x}) &\when Y(\mathbf{p} \concat \mathbf{a}) = \none\\
-      R(\gascounter, \Psi_H(\mathbf{c}, \imath, \gascounter, \registers, \mem, f, \mathbf{x})) &\when Y(\mathbf{p} \concat \mathbf{a}) = (\mathbf{c}, \registers, \mem)\\
+      (0, \panic, \mathbf{x}) &\when Y(\mathbf{p}, \mathbf{a}) = \none\\
+      R(\gascounter, \Psi_H(\mathbf{c}, \imath, \gascounter, \registers, \mem, f, \mathbf{x})) &\when Y(\mathbf{p}, \mathbf{a}) = (\mathbf{c}, \registers, \mem)\\
       \multicolumn{2}{l}{
         \quad \where R \colon (\gascounter, \tup{\begin{alignedat}{5}
           &\varepsilon,\, &&\imath',\, &&\gascounter',\\

--- a/text/pvm.tex
+++ b/text/pvm.tex
@@ -828,8 +828,8 @@ The four instances where the \textsc{pvm} is utilized each expect to be able to 
       \Y, \N_R, \N_G, \Y_{:\mathsf{Z}_I}, \Omega\langle X \rangle, X
     \right) &\to (\N_G, \Y \cup \{\panic, \oog\}, X)\\
     (\mathbf{p}, \imath, \gascounter, \mathbf{a}, f, \mathbf{x}) &\mapsto \begin{cases}
-      (0, \panic, \mathbf{x}) &\when Y(\mathbf{p}) = \none\\
-      R(\gascounter, \Psi_H(\mathbf{c}, \imath, \gascounter, \registers, \mem, f, \mathbf{x})) &\when Y(\mathbf{p}) = (\mathbf{c}, \registers, \mem)\\
+      (0, \panic, \mathbf{x}) &\when Y(\mathbf{p} \concat \mathbf{a}) = \none\\
+      R(\gascounter, \Psi_H(\mathbf{c}, \imath, \gascounter, \registers, \mem, f, \mathbf{x})) &\when Y(\mathbf{p} \concat \mathbf{a}) = (\mathbf{c}, \registers, \mem)\\
       \multicolumn{2}{l}{
         \quad \where R \colon (\gascounter, \tup{\begin{alignedat}{5}
           &\varepsilon,\, &&\imath',\, &&\gascounter',\\


### PR DESCRIPTION
[Program initialization function](https://graypaper.fluffylabs.dev/#/cc517d7/2b64022b6402?v=0.6.5) `Y` expects the program blob `p` to include the argument `a` (per Eq. A.37). 

We now invoke  

`$Y(p, a)`

instead of  
`Y(p)`  


**Changes**  
- In the definition of `\Psi_M`, updated both `Y(p) = …` matches to `Y(p,a) = …`.
- Y accepts **a** as a function argument
- Modified A.37 where we were earlier decoding **a** from **p**
