### PR TITLE
Text change: equation 12.20: change p -> i

### DIFF
--- a/text/accumulation.tex
+++ b/text/accumulation.tex
@@ -232,7 +232,7 @@ The single-service accumulation function, $\Delta_1$, transforms an initial stat
   \end{aligned}\right.\!\!\!\!
 \end{align}
 
-This introduces $\operandtuple$, the set of wrangled \emph{operand tuples}, used as an operand to the \textsc{pvm} Accumulation function $\Psi_A$: work-items (together with associated data in their work-packages) are rephrased into a sequence of such operand tuples $\mathbf{p}$. It also draws upon $\wl¬gaslimit$, the gas limit implied by the work-reports and gas-privileges.
+This introduces $\operandtuple$, the set of wrangled \emph{operand tuples}, used as an operand to the \textsc{pvm} Accumulation function $\Psi_A$: work-items (together with associated data in their work-packages) are rephrased into a sequence of such operand tuples $\mathbf{i}$. It also draws upon $\wl¬gaslimit$, the gas limit implied by the work-reports and gas-privileges.
 
 \subsection{Deferred Transfers and State Integration}
 


### PR DESCRIPTION
Minor omission due to renaming of `p`-to-`i` in single-service accumulation function.