### PR TITLE
Set last byte to 0 in service storage key construction

### DIFF
--- a/text/merklization.tex
+++ b/text/merklization.tex
@@ -12,7 +12,7 @@ We define the state-key constructor functions $C$ as:
     \N_{2^8} \cup (\N_{2^8}, \N_S) \cup \tup{\N_S, \Y} &\to \H \\
     i \in \N_{2^8} &\mapsto [i, 0, 0, \dots] \\
     (i, s \in \N_S) &\mapsto [i, n_0, 0, n_1, 0, n_2, 0, n_3, 0, 0, \dots]\ \where n = \se_4(s) \\
-    (s, h) &\mapsto [n_0, h_0, n_1, h_1, n_2, h_2, n_3, h_3, h_4, h_5, \dots, h_{27}]\ \where n = \se_4(s)
+    (s, h) &\mapsto [n_0, h_0, n_1, h_1, n_2, h_2, n_3, h_3, h_4, h_5, \dots, h_{26}, 0]\ \where n = \se_4(s)
   \end{aligned}
   \right.
 \end{equation}


### PR DESCRIPTION
The last byte is unused in practice and can be safely dropped, which simplifies the process of recovering the original storage key from a trie key (e.g. during test vectors construction or state dumps)

To maintain consistency and convenience - i.e. to keep the 32-byte hashes domain - I propose to change the serialization rule for service keys where the last byte is just set to `0`. This makes the "full" storage key recoverable from the trie key.

![Screenshot_2025-04-30_17-37-27](https://github.com/user-attachments/assets/777af0e5-2a95-4ef4-a537-832928c77383)

A non-zero value can also lead to confusion https://github.com/davxy/jam-test-vectors/pull/45#issuecomment-2840337660

This change does not impact security in any way, as the last byte is already dropped during Merkelization.


