### PR TITLE
make it clearer that statistics relies on `I` and `X`

### DIFF
--- a/text/overview.tex
+++ b/text/overview.tex
@@ -57,11 +57,11 @@ Much as in the \emph{YP}, we specify $\Upsilon$ as the implication of formulatin
   \rho^\ddagger &\prec (\xtassurances, \rho^\dagger) \label{eq:rhoddagger} \\
   \rho' &\prec (\xtguarantees, \rho^\ddagger, \kappa, \tau') \label{eq:rhoprime} \\
   \mathbf{W}^* &\prec (\xtassurances, \rho') \\
-  (\ready', \accumulated', \accountspostxfer, \chi', \iota', \varphi', \beefycommitmap) &\prec (\mathbf{W}^*, \ready, \accumulated, \accountspre, \chi, \iota, \varphi, \tau, \tau') \label{eq:accountspostxfer} \\
+  (\ready', \accumulated', \accountspostxfer, \chi', \iota', \varphi', \beefycommitmap, \mathbf{I}, \mathbf{X}) &\prec (\mathbf{W}^*, \ready, \accumulated, \accountspre, \chi, \iota, \varphi, \tau, \tau') \label{eq:accountspostxfer} \\
   \beta' &\prec (\mathbf{H}, \xtguarantees, \beta^\dagger, \beefycommitmap) \label{eq:betaprime} \\
   \accountspostpreimage &\prec (\xtpreimages, \accountspostxfer, \tau') \label{eq:accountspostpreimage} \\
   \alpha' &\prec (\mathbf{H}, \xtguarantees, \varphi', \alpha) \\
-  \pi' &\prec (\xtguarantees, \xtpreimages, \xtassurances, \xttickets, \tau, \kappa', \pi, \mathbf{H})\!\!\!\!\!\!\!\!
+  \pi' &\prec (\xtguarantees, \xtpreimages, \xtassurances, \xttickets, \tau, \kappa', \pi, \mathbf{H}, \mathbf{I}, \mathbf{X})\!\!\!\!\!\!\!\!
 \end{align}
 
 The only synchronous entanglements are visible through the intermediate components superscripted with a dagger and defined in equations \ref{eq:betadagger}, \ref{eq:rhodagger}, \ref{eq:rhoddagger}, \ref{eq:rhoprime}, \ref{eq:accountspostxfer}, \ref{eq:betaprime} and \ref{eq:accountspostpreimage}. The latter two mark a merge and join in the dependency graph and, concretely, imply that the availability extrinsic may be fully processed and accumulation of work happen before the preimage lookup extrinsic is folded into state.

--- a/text/statistics.tex
+++ b/text/statistics.tex
@@ -1,4 +1,6 @@
-\section{Validator Activity Statistics}\label{sec:bookkeeping}
+\section{Statistics}\label{sec:bookkeeping}
+
+\subsection{Validator Activity}
 
 The \Jam chain does not explicitly issue rewards---we leave this as a job to be done by the staking subsystem (in Polkadot's case envisioned as a system parachain---hosted without fees---in the current imagining of a public \Jam network). However, much as with validator punishment information, it is important for the \Jam chain to facilitate the arrival of information on validator activity in to the staking subsystem so that it may be acted upon.
 
@@ -58,6 +60,8 @@ The objective statistics are updated in line with their description, formally:
 \end{align}
 
 Note that $\mathbf{R}$ is the \emph{Reporters} set, as defined in equation \ref{eq:guarantorsig}.
+
+\subsection{Cores and Services}
 
 The other two components of statistics are the core and service activity statistics. These are tracked only on a per-block basis unlike the validator statistics which are tracked over the whole epoch.
 


### PR DESCRIPTION
This makes it on-par with how `C` (beefy commitments) are passed around in the STF overview.

It also seems like section 13 is no longer just validator statistics, but rather statistics about: 

1. (per epoch) validators
2. (per block) cores / services

I proposed my wording of this, but happy to remove/change that out if preferred.