### PR TITLE
Terminology: rename instances of Polka Virtual Machine to Polkadot Virtual Machine

### DIFF
--- a/text/intro.tex
+++ b/text/intro.tex
@@ -48,7 +48,7 @@ Unlike with \textsc{snark}-based L2-blockchain techniques for scaling, this mode
 
 We begin with a brief overview of present scaling approaches in blockchain technology in section \ref{sec:previouswork}. In section \ref{sec:notation} we define and clarify the notation from which we will draw for our formalisms.
 
-We follow with a broad overview of the protocol in section \ref{sec:overview} outlining the major areas including the Polka Virtual Machine (\textsc{pvm}), the consensus protocols Safrole and \textsc{Grandpa}, the common clock and build the foundations of the formalism.
+We follow with a broad overview of the protocol in section \ref{sec:overview} outlining the major areas including the Polkadot Virtual Machine (\textsc{pvm}), the consensus protocols Safrole and \textsc{Grandpa}, the common clock and build the foundations of the formalism.
 
 We then continue with the full protocol definition split into two parts: firstly the correct on-chain state-transition formula helpful for all nodes wishing to validate the chain state, and secondly, in sections \ref{sec:workpackagesandworkreports} and \ref{sec:bestchain} the honest strategy for the off-chain actions of any actors who wield a validator key.
 

--- a/text/overview.tex
+++ b/text/overview.tex
@@ -140,7 +140,7 @@ We further presume that a number of constant \emph{prices} stated in terms of to
 
 \subsection{The Virtual Machine and Gas}\label{sec:virtualmachineandgas}
 
-In the present work, we presume the definition of a \emph{Polka Virtual Machine} (\textsc{pvm}). This virtual machine is based around the \textsc{risc-v} instruction set architecture, specifically the \textsc{rv}\oldstylenums{64}\textsc{em} variant, and is the basis for introducing permissionless logic into our state-transition function.
+In the present work, we presume the definition of a \emph{Polkadot Virtual Machine} (\textsc{pvm}). This virtual machine is based around the \textsc{risc-v} instruction set architecture, specifically the \textsc{rv}\oldstylenums{64}\textsc{em} variant, and is the basis for introducing permissionless logic into our state-transition function.
 
 The \textsc{pvm} is comparable to the \textsc{evm} defined in the Yellow Paper, but somewhat simpler: the complex instructions for cryptographic operations are missing as are those which deal with environmental interactions. Overall it is far less opinionated since it alters a pre-existing general purpose design, \textsc{risc-v}, and optimizes it for our needs. This gives us excellent pre-existing tooling, since \textsc{pvm} remains essentially compatible with \textsc{risc-v}, including support from the compiler toolkit \textsc{llvm} and languages such as Rust and C++. Furthermore, the instruction set simplicity which \textsc{risc-v} and \textsc{pvm} share, together with the register size (64-bit), active number (13) and endianness (little) make it especially well-suited for creating efficient recompilers on to common hardware architectures.
 

--- a/text/pvm.tex
+++ b/text/pvm.tex
@@ -1,4 +1,4 @@
-\section{Polka Virtual Machine}\label{sec:virtualmachine}
+\section{Polkadot Virtual Machine}\label{sec:virtualmachine}
 
 %TODO: First 64KB of memory is always inaccessible.
 


### PR DESCRIPTION
As per discussions on the graypaper chat and the change that was made in [jam-docs](https://github.com/JamBrains/jam-docs/pull/39).
