### PR TITLE
Fix: Authorizer-trace symbol in the Refine invocation

### DIFF
--- a/text/pvm_invocations.tex
+++ b/text/pvm_invocations.tex
@@ -50,7 +50,7 @@ The Is-Authorized invocation is the first and simplest of the four, being totall
   \label{eq:isauthorizedmutator}F \in \Omega\ang{\{\}} &\colon
     (n, \gascounter, \registers, \memory) \mapsto \begin{cases}
       \Omega_G(\gascounter, \registers, \memory) &\when n = \mathtt{gas} \\
-      \Omega_Y(\gascounter, \registers, \memory, \wpX, \none, \none, \none, \none, \none, \none, \none) &\when n = \mathtt{fetch} \\
+      \Omega_Y(\gascounter, \registers, \memory, \wpX, \H_0, \none, \none, \none, \none, \none, \none) &\when n = \mathtt{fetch} \\
       (\continue, \gascounter - 10, [\registers_0, \dots, \registers_6, \mathtt{WHAT}, \registers_8, \dots], \memory) &\otherwise
     \end{cases}
 \end{align}
@@ -73,7 +73,7 @@ The inner \textsc{pvm} invocation host-calls, meanwhile, depend on an integrated
 
 The Export host-call depends on two pieces of context; one sequence of segments (blobs of length $\mathsf{W}_G$) to which it may append, and the other an argument passed to the invocation function to dictate the number of segments prior which may assumed to have already been appended. The latter value ensures that an accurate segment index can be provided to the caller.
 
-Unlike the other invocation functions, the Refine invocation function implicitly draws upon some recent service account state item $\delta$. The specific block from which this comes is not important, as long as it is no earlier than its work-package's lookup-anchor block. It explicitly accepts the work-package $p$ and the index of the work item to be refined, $i$. Additionally, the authorizer trace $\mathbf{o}$ is provided together with all work items' import segments $\overline{\mathbf{i}}$ and an export segment offset $\segoff$. It results in either some error $\mathbb{J}$ or a pair of the refinement output blob and the export sequence. Formally:
+Unlike the other invocation functions, the Refine invocation function implicitly draws upon some recent service account state item $\delta$. The specific block from which this comes is not important, as long as it is no earlier than its work-package's lookup-anchor block. It explicitly accepts the work-package $p$ and the index of the work item to be refined, $i$. Additionally, the authorizer trace $\mathbf{r}$ is provided together with all work items' import segments $\overline{\mathbf{i}}$ and an export segment offset $\segoff$. It results in either some error $\mathbb{J}$ or a pair of the refinement output blob and the export sequence. Formally:
 \begin{align}
   &\Psi_R \colon \left\{\begin{aligned}
     (\N, \mathbb{P}, \Y, \seq{\seq{\G}}, \N) &\to (\Y \cup \mathbb{J}, \seq{\G}, \N_G) \\
@@ -82,9 +82,9 @@ Unlike the other invocation functions, the Refine invocation function implicitly
       (\token{BIG}, [], 0) &\otherwhen |\Lambda(\delta[w_s], (p_\mathbf{x})_t, w_\wi¬codehash)| > \mathsf{W}_C \\
       &\otherwise: \\
       &\quad\using a = \se(i, w_s, \var{w_\mathbf{y}}, \hash(p))\;,\ \se(\var{\mathbf{z}}, \mathbf{c}) = \Lambda(\delta[w_s], (p_\wp¬context)_t, w_\wi¬codehash)\\
-      &\quad\also (u, \mathbf{r}, (\mathbf{m}, \mathbf{e})) = \Psi_M(\mathbf{c}, 0, w_g, a, F, (\emptyset, []))\ \colon\\
-      (\mathbf{r}, [], u) &\quad\when \mathbf{r} \in \{ \oog, \panic \}  \\
-      (\mathbf{r}, \mathbf{e}, u) &\quad\otherwise \\
+      &\quad\also (u, \mathbf{o}, (\mathbf{m}, \mathbf{e})) = \Psi_M(\mathbf{c}, 0, w_g, a, F, (\emptyset, []))\ \colon\\
+      (\mathbf{o}, [], u) &\quad\when \mathbf{o} \in \{ \oog, \panic \}  \\
+      (\mathbf{o}, \mathbf{e}, u) &\quad\otherwise \\
       \multicolumn{2}{l}{\where w = p_\wp¬workitems[i]}
     \end{cases} \\
   \end{aligned}\right. \\

--- a/text/pvm_invocations.tex
+++ b/text/pvm_invocations.tex
@@ -50,7 +50,7 @@ The Is-Authorized invocation is the first and simplest of the four, being totall
   \label{eq:isauthorizedmutator}F \in \Omega\ang{\{\}} &\colon
     (n, \gascounter, \registers, \memory) \mapsto \begin{cases}
       \Omega_G(\gascounter, \registers, \memory) &\when n = \mathtt{gas} \\
-      \Omega_Y(\gascounter, \registers, \memory, \wpX, \H_0, \none, \none, \none, \none, \none, \none) &\when n = \mathtt{fetch} \\
+      \Omega_Y(\gascounter, \registers, \memory, \wpX, \none, \none, \none, \none, \none, \none, \none) &\when n = \mathtt{fetch} \\
       (\continue, \gascounter - 10, [\registers_0, \dots, \registers_6, \mathtt{WHAT}, \registers_8, \dots], \memory) &\otherwise
     \end{cases}
 \end{align}


### PR DESCRIPTION
In #372, the Refine invocation function (`Ψ_R`) renamed the auth trace parameter from `\mathbf{o}` as `\mathbf{r}`, this PR ensures consistency in the related symbols:

## Changes:

1. In `Ψ_R`, `\mathbf{r}` was earlier used to denote the result variable from `\Psi_M`. I've updated this to `\mathbf{o}` to represent the "output" value to avoid conflict with updated authority trace argument `\mathbf{r}`
  
2. Updating text definition `authorizer trace o` to `authorizer trace r`

Making this change to be carefully limited to adjusting only the \Psi_M result notation while preserving the auth trace parameter as \mathbf{r} per PR #372. This avoids potential confusion with the \Omega_Y fetch function which has a separate \mathbf{o} parameter unrelated to auth trace.

<img width="812" alt="image" src="https://github.com/user-attachments/assets/fa36f5f9-7104-4106-a0e4-a5fd226083de" />

Changed to:
<img width="1035" alt="image" src="https://github.com/user-attachments/assets/3188550c-def6-446b-93a0-d9e4136d6846" />

Note: While \¬authtrace is defined in preamble.tex as \mathbf{o}, there's a TODO comment (% TODO: Consider renaming to \mathbf{u} to free up \mathbf{o}), suggesting eventual refactoring. This PR addresses the immediate inconsistency without requiring a larger symbol restructuring. I'd be happy to raise a PR for the restructuring as well : )