### PR TITLE
fix: encode px in fetch invocation

### DIFF
--- a/text/pvm_invocations.tex
+++ b/text/pvm_invocations.tex
@@ -345,7 +345,7 @@ Other than the gas-counter which is explicitly defined, elements of \textsc{pvm}
       \se(p) &\when p \ne \none \wedge \registers_{10} = 7 \\
       \se(p_\wp¬authcodehash, \var{p_\wp¬authconfig}) &\when p \ne \none \wedge \registers_{10} = 8 \\
       p_\wp¬authtoken &\when p \ne \none \wedge \registers_{10} = 9 \\
-      p_\wp¬context &\when p \ne \none \wedge \registers_{10} = 10 \\
+      \se(p_\wp¬context) &\when p \ne \none \wedge \registers_{10} = 10 \\
       \se(\var{\sq{S(w) \mid w \orderedin p_\wp¬workitems}}) &\when p \ne \none \wedge \registers_{10} = 11 \\
       S(p_\wp¬workitems[\registers_{11}]) &\when p \ne \none \wedge \registers_{10} = 12 \wedge \registers_{11} < |p_\wp¬workitems| \\
       \multicolumn{2}{l}{\where S(w) \equiv \se(\se_4(w_\wi¬service), w_\wi¬codehash, \se_8(w_\wi¬refgaslimit, w_\wi¬accgaslimit), \se_2(w_\wi¬exportcount, |w_\wi¬importsegments|, |w_\wi¬extrinsics|), \se_4(|w_\wi¬payload|))} \\


### PR DESCRIPTION
While implementing the fetch function we noticed that the work-package context `px` should be serialised:
<img width="1038" alt="image" src="https://github.com/user-attachments/assets/4772a56d-404f-470e-9dbe-2fc7cba0d245" />

Change:
<img width="842" alt="image" src="https://github.com/user-attachments/assets/59ccad0f-aa41-4749-9c69-e0672809f7fa" />
