### PR TITLE
typo: refine-fetch should pass Null instead of H0

### DIFF
--- a/text/pvm_invocations.tex
+++ b/text/pvm_invocations.tex
@@ -92,7 +92,7 @@ Unlike the other invocation functions, the Refine invocation function implicitly
   &F \in \Omega\ang{(\dict{\N}{\pvm}, \seq{\G})} \colon
     (n, \gascounter, \registers, \memory, (\mathbf{m}, \mathbf{e})) \mapsto \begin{cases}
       \Omega_G(\gascounter, \registers, \memory, (\mathbf{m}, \mathbf{e})) &\when n = \mathtt{gas} \\
-      \Omega_Y(\gascounter, \registers, \memory, p, \H_0, \mathbf{r}, i, \overline{\mathbf{i}}, \overline{\mathbf{x}}, \none, \none, (\mathbf{m}, \mathbf{e})) &\when n = \mathtt{fetch}\\
+      \Omega_Y(\gascounter, \registers, \memory, p, \none, \mathbf{r}, i, \overline{\mathbf{i}}, \overline{\mathbf{x}}, \none, \none, (\mathbf{m}, \mathbf{e})) &\when n = \mathtt{fetch}\\
       \Omega_H(\gascounter, \registers, \memory, (\mathbf{m}, \mathbf{e}), w_s, \delta, (p_\mathbf{x})_t) &\when n = \mathtt{historical\_lookup}\\
       \Omega_E(\gascounter, \registers, \memory, (\mathbf{m}, \mathbf{e}), \segoff) &\when n = \mathtt{export}\\
       \Omega_M(\gascounter, \registers, \memory, (\mathbf{m}, \mathbf{e})) &\when n = \mathtt{machine}\\


### PR DESCRIPTION
Since we are checking if `n` is None in fetch call as such:
<img width="468" alt="image" src="https://github.com/user-attachments/assets/36299dfd-e45d-4855-826a-77cfe42ee512" />

<img width="492" alt="image" src="https://github.com/user-attachments/assets/180596ae-49b0-43c1-9595-373a21ac3dda" />

it should be passed as None instead of H0 in B.6

<img width="538" alt="image" src="https://github.com/user-attachments/assets/0d5d0be1-8c12-42eb-b82a-89815f0aedd4" />
