### PR TITLE
Misc: Cores are property

### DIFF
--- a/preamble.tex
+++ b/preamble.tex
@@ -229,6 +229,10 @@
 \newcommand*{\ot¬gaslimit}{\¬gaslimit}
 \newcommand*{\ot¬result}{\¬result}
 
+\newcommand*{\manager}{\chi_m}
+\newcommand*{\delegater}{\chi_v}
+\newcommand*{\assigners}{\chi_\mathbf{a}}
+\newcommand*{\alwaysaccers}{\chi_\mathbf{g}}
 \newcommand*{\accumulated}{\xi}
 \newcommand*{\ready}{\vartheta}
 

--- a/text/accounts.tex
+++ b/text/accounts.tex
@@ -145,14 +145,14 @@ We may then define a second dependent term $t$, the minimum, or \emph{threshold}
 
 
 \subsection{Service Privileges}
-Up to three services may be recognized as privileged. The portion of state in which this is held is denoted $\chi$ and has three service index components together with a gas limit. The first, $\chi_m$, is the index of the \emph{manager} service which is the service able to effect an alteration of $\chi$ from block to block. The following two, $\chi_a$ and $\chi_v$, are each the indices of services able to alter $\varphi$ and $\iota$ from block to block.
+Up to three services may be recognized as privileged. The portion of state in which this is held is denoted $\chi$ and has three service index components together with a gas limit. The first, $\manager$, is the index of the \emph{manager} service which is the service able to effect an alteration of $\chi$ from block to block. The following, $\assigners$, are the service indices capable of altering the authorizer queue $\varphi$, one for each core. The next, $\delegater$, is able to set $\iota$.
 
-Finally, $\chi_\mathbf{g}$ is a small dictionary containing the indices of services which automatically accumulate in each block together with a basic amount of gas with which each accumulates. Formally:
+Finally, $\alwaysaccers$ is a small dictionary containing the indices of services which automatically accumulate in each block together with a basic amount of gas with which each accumulates. Formally:
 \begin{align}
   \chi \equiv \tuple{
-    \isa{\chi_m}{\N_S} \ts
-    \isa{\chi_a}{\N_S} \ts
-    \isa{\chi_v}{\N_S} \ts
-    \isa{\chi_\mathbf{g}}{\dict{\N_S}{\N_G}}
+    \isa{\manager}{\N_S} ,
+    \isa{\assigners}{\seq{\N_S}_\mathsf{C}} ,
+    \isa{\delegater}{\N_S} ,
+    \isa{\alwaysaccers}{\dict{\N_S}{\N_G}}
   }
 \end{align}

--- a/text/accumulation.tex
+++ b/text/accumulation.tex
@@ -102,13 +102,22 @@ Our formalisms begin by defining $\partialstate$ as a characterization of (\ie v
     &\isa{\mathbf{d}}{\dict{\N_S}{\mathbb{A}}} \,,\;
     \isa{\mathbf{i}}{\seq{\mathbb{K}}_\mathsf{V}} \,,\;
     \isa{\mathbf{q}}{\seq{\seq{\H}_\mathsf{Q}}_\mathsf{C}} \,,\\
-    &\isa{\mathbf{x}}{(\N_S,\N_S,\N_S,\dict{\N_S}{\N_G})}
+    &\isa{m}{\N_S} \,,\;
+    \isa{\mathbf{a}}{\seq{\N_S}_\mathsf{C}} \,,\;
+    \isa{v}{\N_S} \,,\;
+    \isa{\mathbf{z}}{\dict{\N_S}{\N_G}}
   \end{aligned}\right)
 \end{equation}
 
 We denote the set characterizing a \emph{deferred transfer} as $\defxfer$, noting that a transfer includes a memo component $m$ of $\mathsf{W}_T = 128$ octets, together with the service index of the sender $s$, the service index of the receiver $d$, the balance to be transferred $a$ and the gas limit $g$ for the transfer. Formally:
 \begin{align}
-  \defxfer \equiv \ltuple\isa{s}{\N_S}\ts\isa{d}{\N_S}\ts\isa{a}{\N_B}\ts\isa{m}{\Y_{\mathsf{W}_T}}\ts\isa{g}{\N_G}\rtuple
+  \defxfer \equiv \tuple{
+    \isa{s}{\N_S} ,
+    \isa{d}{\N_S} ,
+    \isa{a}{\N_B} ,
+    \isa{m}{\Y_{\mathsf{W}_T}} ,
+    \isa{g}{\N_G}
+  }
 \end{align}
 
 Finally, we denote the set of service/hash pairs, utilized as a service-indexed commitment to the accumulation output, as $\servouts$:
@@ -132,11 +141,11 @@ We define the outer accumulation function $\Delta_+$ which transforms a gas-limi
   \end{aligned}\right.
 \end{equation}
 
-We come to define the parallelized accumulation function $\Delta_*$ which, with the help of the single-service accumulation function $\Delta_1$, transforms an initial state-context, together with a sequence of work-reports and a dictionary of privileged always-accumulate services, into a tuple of the total gas utilized in \textsc{pvm} execution $u$, a posterior state-context $(\mathbf{x}', \mathbf{d}', \mathbf{i}', \mathbf{q}')$ and the resultant accumulation-output pairings $\mathbf{b}$ and deferred-transfers $\wideparen{\mathbf{t}}$:
+We come to define the parallelized accumulation function $\Delta_*$ which, with the help of the single-service accumulation function $\Delta_1$, transforms an initial state-context, together with a sequence of work-reports and a dictionary of privileged always-accumulate services, into a tuple of the total gas utilized in \textsc{pvm} execution $u$, a posterior state-context $(\mathbf{d}', \mathbf{i}', \mathbf{q}', m', \mathbf{a}', v', \mathbf{x}')$ and the resultant accumulation-output pairings $\mathbf{b}$ and deferred-transfers $\wideparen{\mathbf{t}}$:
 \begin{equation}
   \Delta_*\colon\left\{\;\begin{aligned}
     &(\partialstate, \seq{\mathbb{W}}, \dict{\N_S}{\N_G}) \to (\partialstate, \defxfers, \servouts, \gasused) \\
-    &(\mathbf{o}, \mathbf{w}, \mathbf{f}) \mapsto ((\mathbf{d}', \mathbf{i}', \mathbf{q}', \mathbf{x}'), \wideparen{\mathbf{t}}, \mathbf{b}, \mathbf{u})\!\!\!\!\!\!\\
+    &(\mathbf{o}, \mathbf{w}, \mathbf{f}) \mapsto ((\mathbf{d}', \mathbf{i}', \mathbf{q}', m', \mathbf{a}', v', \mathbf{z}'), \wideparen{\mathbf{t}}, \mathbf{b}, \mathbf{u})\!\!\!\!\!\!\\
     &\text{where:}\\
     &\ \begin{aligned}
       \mathbf{s} &= \{ \mathbf{r}_s \mid w \in \mathbf{w}, \mathbf{r} \in w_\mathbf{r} \} \cup \keys{\mathbf{f}} \\
@@ -144,10 +153,11 @@ We come to define the parallelized accumulation function $\Delta_*$ which, with 
       \mathbf{b} &= \{ (s, b) \mid s \in \mathbf{s},\, b = \Delta_1(\mathbf{o}, \mathbf{w}, \mathbf{f}, s)_b,\, b \ne \none \} \\
       \mathbf{t} &= [\Delta_1(\mathbf{o}, \mathbf{w}, \mathbf{f}, s)_\mathbf{t} \mid s \orderedin \mathbf{s}] \\
       \mathbf{d}' &= \fnprovide((\mathbf{d} \cup \mathbf{n}) \setminus \mathbf{m}, \bigcup_{s \in \mathbf{s}} \Delta_1(\mathbf{o}, \mathbf{w}, \mathbf{f}, s)_\mathbf{p}) \\
-      &(\mathbf{d}, \mathbf{i}, \mathbf{q}, (m, a, v, \mathbf{z})) = \mathbf{o} \\
-      \mathbf{x}' &= (\Delta_1(\mathbf{o}, \mathbf{w}, \mathbf{f}, m)_\mathbf{o})_\mathbf{x} \\
+      &(\mathbf{d}, \mathbf{i}, \mathbf{q}, m, \mathbf{a}, v, \mathbf{z}) = \mathbf{o} \\
+      (m', \mathbf{a}^*, v', \mathbf{z}') &= (\Delta_1(\mathbf{o}, \mathbf{w}, \mathbf{f}, m)_\mathbf{o})_{(m, \mathbf{a}, v, \mathbf{z})} \\ % Allow for core-owners to transfer their ownership.
+      \forall c \in \N_\mathsf{C} : \mathbf{a}'_c &= ((\Delta_1(\mathbf{o}, \mathbf{w}, \mathbf{f}, \mathbf{a}^*_c)_\mathbf{o})_\mathbf{a})_c \\
       \mathbf{i}' &= (\Delta_1(\mathbf{o}, \mathbf{w}, \mathbf{f}, v)_\mathbf{o})_\mathbf{i} \\
-      \mathbf{q}' &= (\Delta_1(\mathbf{o}, \mathbf{w}, \mathbf{f}, a)_\mathbf{o})_\mathbf{q} \\
+      \forall c \in \N_\mathsf{C} : \mathbf{q}'_c &= (\Delta_1(\mathbf{o}, \mathbf{w}, \mathbf{f}, \mathbf{a}_c)_\mathbf{o})_\mathbf{q} \\
       \mathbf{n} &= \bigcup_{s \in \mathbf{s}}(\{ (\Delta_1(\mathbf{o}, \mathbf{w}, \mathbf{f}, s)_\mathbf{o})_\mathbf{d} \setminus \keys{\mathbf{d} \setminus \{s\}} \}) \\
       \mathbf{m} &= \bigcup_{s \in \mathbf{s}}(\keys{\mathbf{d}} \setminus \keys{(\Delta_1(\mathbf{o}, \mathbf{w}, \mathbf{f}, s)_\mathbf{o})_\mathbf{d}})
     \end{aligned}
@@ -238,8 +248,8 @@ This introduces $\operandtuple$, the set of wrangled \emph{operand tuples}, used
 
 Given the result of the top-level $\Delta_+$, we may define the posterior state $\chi'$, $\varphi'$ and $\iota'$ as well as the first intermediate state of the service-accounts $\accountspostacc$ and the \textsc{Beefy} commitment map $\beefycommitmap$:
 \begin{align}
-  \using &g = \max\left(\mathsf{G}_T, \mathsf{G}_A\cdot \mathsf{C} + \textstyle \sum_{x \in \mathcal{V}(\chi_\mathbf{g})}(x)\right)\\
-  \using &(n, \mathbf{o}, \mathbf{t}, \beefycommitmap, \mathbf{u}) = \Delta_+(g, \mathbf{W}^*, (\chi, \accountspre, \iota, \varphi), \chi_\mathbf{g}) \\
+  \using &g = \max\left(\mathsf{G}_T, \mathsf{G}_A\cdot \mathsf{C} + \textstyle \sum_{x \in \mathcal{V}(\alwaysaccers)}(x)\right)\\
+  \using &(n, \mathbf{o}, \mathbf{t}, \beefycommitmap, \mathbf{u}) = \Delta_+(g, \mathbf{W}^*, (\chi, \accountspre, \iota, \varphi), \alwaysaccers) \\
   &(\chi', \accountspostacc, \iota', \varphi') \equiv \mathbf{o}
 \end{align}
 

--- a/text/definitions.tex
+++ b/text/definitions.tex
@@ -232,10 +232,10 @@ Here, the prime annotation indicates posterior state. Individual components may 
   \end{description}
   \item[$\chi$] The privileged service indices. %	χ
   \begin{description}
-    \item[$\chi_m$] The index of the blessed service.
-    \item[$\chi_v$] The index of the designate service.
-    \item[$\chi_a$] The index of the assign service.
-    \item[$\chi_\mathbf{g}$] The always-accumulate service indices and their basic gas allowance.
+    \item[$\manager$] The index of the blessed service.
+    \item[$\delegater$] The index of the designate service.
+    \item[$\assigners$] The indices of the services able to assign each core's authorizer queue.
+    \item[$\alwaysaccers$] The always-accumulate service indices and their basic gas allowance.
   \end{description}
   \item[$\pi$] The activity statistics for the validators. % π
   \item[$\vartheta$] The accumulation queue. % ϑ
@@ -270,7 +270,7 @@ Here, the prime annotation indicates posterior state. Individual components may 
   \item[$\mathsf{G}_A = 10,000,000$] The gas allocated to invoke a work-report's Accumulation logic.
   \item[$\mathsf{G}_I = 50,000,000$] The gas allocated to invoke a work-package's Is-Authorized logic.
   \item[$\mathsf{G}_R = 5,000,000,000$] The gas allocated to invoke a work-package's Refine logic.
-  \item[$\mathsf{G}_T = 3,500,000,000$] The total gas allocated across for all Accumulation. Should be no smaller than $\mathsf{G}_A\cdot\mathsf{C} + \sum_{g \in \mathcal{V}(\chi_\mathbf{g})}(g)$.
+  \item[$\mathsf{G}_T = 3,500,000,000$] The total gas allocated across for all Accumulation. Should be no smaller than $\mathsf{G}_A\cdot\mathsf{C} + \sum_{g \in \mathcal{V}(\alwaysaccers)}(g)$.
   \item[$\mathsf{H} = 8$] The size of recent history, in blocks.
   \item[$\mathsf{I} = 16$] The maximum amount of work items in a package.
   \item[$\mathsf{J} = 8$] The maximum sum of dependency items in a work-report.

--- a/text/merklization.tex
+++ b/text/merklization.tex
@@ -35,7 +35,7 @@ The state serialization is then defined as the dictionary built from the amalgam
     &&C(9) &\mapsto \se(\lambda) \;, \\
     &&C(10) &\mapsto \se([\maybe{(w, \se_4(t))} \mid (w, t) \orderedin \rho]) \;, \\
     &&C(11) &\mapsto \se_4(\tau) \;, \\
-    &&C(12) &\mapsto \se_4(\chi_m, \chi_a, \chi_v) \concat \se(\chi_\mathbf{g}) \;, \\
+    &&C(12) &\mapsto \se_4(\manager, \assigners, \delegater) \concat \se(\alwaysaccers) \;, \\
     &&C(13) &\mapsto \se(\se^\#_4(\pi_V), \se^\#_4(\pi_L), \pi_C, \pi_S) \;, \\
     &&C(14) &\mapsto \se([\var{(\mathbf{w}, \var{\mathbf{d}})} \mid (\mathbf{w}, \mathbf{d}) \orderedin \mathbf{i} \mid \mathbf{i} \orderedin \ready]) \;, \\
     &&C(15) &\mapsto \se([\var{\mathbf{i}} \mid \mathbf{i} \orderedin \accumulated]) \;, \\

--- a/text/pvm_invocations.tex
+++ b/text/pvm_invocations.tex
@@ -697,14 +697,18 @@ Other than the gas-counter which is explicitly defined, elements of \textsc{pvm}
   $g = 10$}&
   $\begin{aligned}
     \using [m, a, v, o, n] &= \registers_{7 \dots+ 5} \\
-    \using \mathbf{g} &= \begin{cases}
+    \using \mathbf{a} &= \begin{cases}
+      \de_4(\memory_{a\dots+4\mathsf{C}}) &\when \mathbb{N}_{a \dots+ 4\mathsf{C}} \subseteq \mathbb{V}_{\memory} \\
+      \error &\otherwise
+    \end{cases} \\
+    \using \mathbf{z} &= \begin{cases}
       \left\{ (s \mapsto g) \ \where \se_4(s) \concat \se_8(g) = \memory_{o+12i\dots+12} \mid i \in \N_n \right\} &\when \mathbb{N}_{o \dots+ 12n} \subseteq \mathbb{V}_{\memory} \\
       \error &\otherwise
     \end{cases} \\
-    (\execst', \registers'_7, (\mathbf{x}'_\mathbf{u})_\mathbf{x}) &= \begin{cases}
-      (\panic, \registers_7, (\mathbf{x}_\mathbf{u})_\mathbf{x}) &\when \mathbf{g} = \error\\
-      (\continue, \mathtt{WHO}, (\mathbf{x}_\mathbf{u})_\mathbf{x}) &\otherwhen (m, a, v) \not\in (\N_S, \N_S, \N_S) \\
-      (\continue, \mathtt{OK}, \tuple{m, a, v, \mathbf{g}}) &\otherwise \\
+    (\execst', \registers'_7, (\mathbf{x}'_\mathbf{u})_{(m, \mathbf{a}, v, \mathbf{z})}) &= \begin{cases}
+      (\panic, \registers_7, (\mathbf{x}_\mathbf{u})_{(m, \mathbf{a}, v, \mathbf{z})}) &\when \{\mathbf{z}, \mathbf{a}\} \ni \error \\
+      (\continue, \mathtt{WHO}, (\mathbf{x}_\mathbf{u})_{(m, \mathbf{a}, v, \mathbf{z})}) &\otherwhen (m, v) \not\in (\N_S, \N_S) \\
+      (\continue, \mathtt{OK}, \tuple{m, \mathbf{a}, v, \mathbf{z}}) &\otherwise \\
     \end{cases}
   \end{aligned}$\\
   \cmidrule(lr){1-1}\cmidrule(lr){2-2}

--- a/text/statistics.tex
+++ b/text/statistics.tex
@@ -95,7 +95,7 @@ The other two components of statistics are the core and service activity statist
 The core statistics are updated using several intermediate values from across the overall state-transition function; $\mathbf{w}$, the incoming work-reports, as defined in \ref{eq:incomingworkreports} and $\mathbf{W}$, the newly available work-reports, as defined in \ref{eq:availableworkreports}. We define the statistics as follows:
 
 \begin{align}
-  \forall c \in \N_C : \pi'_C[c] &\equiv \tup{
+  \forall c \in \N_\mathsf{C} : \pi'_C[c] &\equiv \tup{
     \begin{alignedat}{5}
       \is{i&}{R(c)_i}\,,\;
       \is{&x&}{R(c)_x}\,,\;
@@ -107,9 +107,9 @@ The core statistics are updated using several intermediate values from across th
       \is{&p&}{\span\span \textstyle \sum_{a \in \mathbf{E}_A} a_f[c]\qquad}
     \end{alignedat}
   }\!\!\!\!\\
-  \where R(c \in \N_C) &\equiv \!\!\!\!\!\!\!\!\!\!\!\sum_{r \in w_\mathbf{r}, w \in \mathbf{w}, w_c = c}
+  \where R(c \in \N_\mathsf{C}) &\equiv \!\!\!\!\!\!\!\!\!\!\!\sum_{r \in w_\mathbf{r}, w \in \mathbf{w}, w_c = c}
   \!\!\!\!\!\!\!\!\!\!\!(r_i, r_x, r_z, r_e, r_u, \is{b}{(w_s)_l})\\
-  \also D(c \in \N_C) &\equiv \!\!\!\!\!\!\sum_{w \in \mathbf{W}, w_c = c}
+  \also D(c \in \N_\mathsf{C}) &\equiv \!\!\!\!\!\!\sum_{w \in \mathbf{W}, w_c = c}
   \!\!\!\!\!\!(w_s)_l + \mathsf{W}_G\ceil{(w_s)_n\nicefrac{65}{64}}
 \end{align}
 


### PR DESCRIPTION
Closes #386 

This alters the privileged services state items $\chi$ and its associated accumulation shadow to split out the assignment privilege across all cores.

A service privileged in this way for a some core is able not only to assign its authorizer queue, but also to transfer the rights to another service, allowing for the possibility of a nullified manager privilege without fixing the authorizer service.