### PR TITLE
PVM Invocations: Tweak chain params

### DIFF
--- a/text/definitions.tex
+++ b/text/definitions.tex
@@ -283,7 +283,6 @@ Here, the prime annotation indicates posterior state. Individual components may 
   \item[$\mathsf{P} = 6$] The slot period, in seconds.
   \item[$\mathsf{Q} = 80$] The number of items in the authorizations queue.
   \item[$\mathsf{R} = 10$] The rotation period of validator-core assignments, in timeslots.
-  \item[$\mathsf{S} = 1024$] The maximum number of entries in the accumulation queue.
   \item[$\mathsf{T} = 128$] The maximum number of extrinsics in a work-package.
   \item[$\mathsf{U} = 5$] The period in timeslots after which reported but unavailable work may be replaced.
   \item[$\mathsf{V} = 1023$] The total number of validators.

--- a/text/pvm_invocations.tex
+++ b/text/pvm_invocations.tex
@@ -313,23 +313,23 @@ Other than the gas-counter which is explicitly defined, elements of \textsc{pvm}
           \se_2(\mathsf{H}),
           \se_2(\mathsf{I}),
           \se_2(\mathsf{J}),
-          \se_4(\mathsf{L}),
-          \se_2(\mathsf{O}),\\
-          &\se_2(\mathsf{P}),
+          \se_2(\mathsf{K}),\\
+          &\se_4(\mathsf{L}),
+          \se_2(\mathsf{N}),
+          \se_2(\mathsf{O}),
+          \se_2(\mathsf{P}),
           \se_2(\mathsf{Q}),
           \se_2(\mathsf{R}),
-          \se_2(\mathsf{S}),
           \se_2(\mathsf{T}),
-          \se_2(\mathsf{U}),
-          \se_2(\mathsf{V}),
-          \se_4(\mathsf{W}_A),\\
-          &\se_4(\mathsf{W}_B),
+          \se_2(\mathsf{U}),\\
+          &\se_2(\mathsf{V}),
+          \se_4(\mathsf{W}_A),
+          \se_4(\mathsf{W}_B),
           \se_4(\mathsf{W}_C),
           \se_4(\mathsf{W}_E),
-          \se_4(\mathsf{W}_G),
-          \se_4(\mathsf{W}_M),
-          \se_4(\mathsf{W}_P),\\
-          &\se_4(\mathsf{W}_R),
+          \se_4(\mathsf{W}_M),\\
+          &\se_4(\mathsf{W}_P),
+          \se_4(\mathsf{W}_R),
           \se_4(\mathsf{W}_T),
           \se_4(\mathsf{W}_X),
           \se_4(\mathsf{Y})


### PR DESCRIPTION
Removed S, since it is not used (also from definitions)
Removed Wg (segment size), since it can be calculated as Wp*We

Added K (maximum number of tickets) and N (number of tickets per validator) for consistency. These may be resonably different between e.g. full and tiny config. It would make everyone's life easier if the same encoded struct can be used on-chain and off-chain to keep track of all the protocol parameters that may differ.

<img width="819" alt="image" src="https://github.com/user-attachments/assets/8483bc67-2bdf-4ead-99e7-17681092432d" />
