### PR TITLE
chore(invocation): encode operands instead of length of operands

### DIFF
--- a/text/pvm_invocations.tex
+++ b/text/pvm_invocations.tex
@@ -138,7 +138,7 @@ We define $\Psi_A$, the Accumulation invocation function as:
     \tuple{\partialstate, \defxfers, \H\bm{?}, \N_G, \seq{\tuple{\N_S, \Y}}} \\
     (\mathbf{u}, t, s, g, \mathbf{o}) &\mapsto \begin{cases}
       \tup{\mathbf{u}, [], \none, 0, \sq{}} &\when \mathbf{c} = \none \vee |\mathbf{c}| > \mathsf{W}_C \\
-      C(\Psi_M(\mathbf{c}, 5, g, \se(t, s, |\mathbf{o}|), F, I(\mathbf{u}, s)^2)) &\otherwise \\
+      C(\Psi_M(\mathbf{c}, 5, g, \se(t, s, \mathbf{o}), F, I(\mathbf{u}, s)^2)) &\otherwise \\
       \where \mathbf{c} = \mathbf{u}_\mathbf{d}[s]_\mathbf{c}&
     \end{cases} \\
   \end{aligned}\right.\\


### PR DESCRIPTION
as we can see in the [source code](https://docs.rs/jam-pvm-common/latest/src/jam_pvm_common/service.rs.html#33) of jam-pvm-common, the `AccumulateParams` is `(slot, id, results)` where the results are `Vec<AccumulateItem>` in jam-types and `Operands` in graypaper, thus it should be the instances instead of length for arguments