### PR TITLE
fix: digest code hash typo

### DIFF
--- a/text/reporting_assurance.tex
+++ b/text/reporting_assurance.tex
@@ -331,7 +331,7 @@ We require that any segment roots mentioned in the segment-root lookup be verifi
 
 Finally, we require that all work-digests within the extrinsic predicted the correct code hash for their corresponding service:
 \begin{align}\label{eq:reportcodesarecorrect}
-  \forall w \in \mathbf{w}, \forall r \in w_r : r_c = \delta[r_s]_c
+  \forall w \in \mathbf{w}, \forall r \in w_r : {r_\wl¬codehash} = \delta[r_s]_c
 \end{align}
 
 

--- a/text/serialization.tex
+++ b/text/serialization.tex
@@ -149,13 +149,13 @@ A block $\mathbf{B}$ is serialized as a tuple of its elements in regular order, 
   \se_U(\mathbf{H}) &= \se(\mathbf{H}_p,\mathbf{H}_r,\mathbf{H}_x)\concat\se_4(\mathbf{H}_t)\concat\se(\maybe{\mathbf{H}_e},\maybe{\mathbf{H}_w},\se_2(\mathbf{H}_i),\mathbf{H}_v,\var{\mathbf{H}_o})\\
   \se(x \in \mathbb{X}) &\equiv \se(x_a, x_s, x_b, x_l)\concat\se_4(x_t)\concat\se(\var{x_\mathbf{p}})\\
   \se(x \in \avspec) &\equiv \se(x_h) \concat \se_4(x_l)\concat\se(x_u, x_e) \concat \se_2(x_n) \\
-  \se(x \in \mathbb{L}) &\equiv \se(\se_4(x_s), x_c, x_y, \se_8(x_g), x_u, x_i, x_x, x_z, x_e, \seresult(x_\wl¬result))\\
+  \se(x \in \mathbb{L}) &\equiv \se(\se_4(x_s), {x_\wl¬codehash}, x_y, \se_8(x_g), x_u, x_i, x_x, x_z, x_e, \seresult(x_\wl¬result))\\
   \se(x \in \mathbb{W}) &\equiv \se(x_s, x_x, x_c, x_a, x_g, \var{x_\wr¬authtrace}, \var{x_\mathbf{l}}, \var{x_\wr¬digests}) \\
   \se(x \in \mathbb{P}) &\equiv \se(\se_4(x_\wp¬authcodehost), x_\wp¬authcodehash, x_\wp¬context, \var{x_\wp¬authtoken}, \var{x_\wp¬authconfig}, \var{x_\wp¬workitems}) \\
   % TODO: \se_4(i) should be just \se(i), but we should wait for this to be written.
   \se(x \in \mathbb{I}) &\equiv \se(
     \se_4(x_s),
-    x_c,
+    x_h,
     \se_8(x_g),
     \se_8(x_a),
     \se_2(x_e)


### PR DESCRIPTION
Work digest and item code hash is defined as `h`, while being referred as `c` in serialization and 11.42

<img width="574" alt="image" src="https://github.com/user-attachments/assets/80dff022-312b-4ff7-8820-56fd9d33f3b8" />

<img width="843" alt="image" src="https://github.com/user-attachments/assets/2557d85d-49fe-46ce-9a40-b14ebd1822fd" />


Changed to:
<img width="574" alt="image" src="https://github.com/user-attachments/assets/43aa35e7-8fb0-475c-8051-c0ee1c9ae5bc" />

<img width="843" alt="image" src="https://github.com/user-attachments/assets/d993b816-3fe6-4082-8c06-fea72c227168" />
