### PR TITLE
PVM Invocations: swap HUH and CORE condition checks in `assign` hostcall

### DIFF
--- a/text/pvm_invocations.tex
+++ b/text/pvm_invocations.tex
@@ -714,8 +714,8 @@ Other than the gas-counter which is explicitly defined, elements of \textsc{pvm}
     \end{cases} \\
     (\execst', \registers'_7, (\mathbf{x}'_\mathbf{u})_\mathbf{q}[c], (\mathbf{x}'_\mathbf{u})_\mathbf{a}[c]) &= \begin{cases}
       (\panic, \registers_7, (\mathbf{x}_\mathbf{u})_\mathbf{q}[c], (\mathbf{x}_\mathbf{u})_\mathbf{a}[c]) &\when \mathbf{q} = \error \\
-      (\continue, \mathtt{HUH}, (\mathbf{x}_\mathbf{u})_\mathbf{q}[c], (\mathbf{x}_\mathbf{u})_\mathbf{a}[c]) &\otherwhen \mathbf{x}_s \ne (\mathbf{x}_\mathbf{u})_\mathbf{a}[c]\\
       (\continue, \mathtt{CORE}, (\mathbf{x}_\mathbf{u})_\mathbf{q}[c], (\mathbf{x}_\mathbf{u})_\mathbf{a}[c]) &\otherwhen c \ge \corecount \\
+      (\continue, \mathtt{HUH}, (\mathbf{x}_\mathbf{u})_\mathbf{q}[c], (\mathbf{x}_\mathbf{u})_\mathbf{a}[c]) &\otherwhen \mathbf{x}_s \ne (\mathbf{x}_\mathbf{u})_\mathbf{a}[c]\\
       (\continue, \mathtt{OK}, \mathbf{q}, a) &\otherwise \\
     \end{cases} \\
   \end{aligned}$\\


### PR DESCRIPTION
Since `HUH` condition check of `assign` hostcall involves indexing into the assign services with core index _c_, placing `CORE` condition check first would improve logical flow.