### PR TITLE
Definitions: Fix typo in Bandersnatch signature definition

### DIFF
--- a/text/definitions.tex
+++ b/text/definitions.tex
@@ -53,8 +53,8 @@
   \item[$\readable{\memory}$] The set of $\mathbb{V}$alidly readable indices for \textsc{pvm} \textsc{ram} $\memory$. See appendix \ref{sec:virtualmachine}.
   \item[$\writable{\memory}$] The set of $\mathbb{V}$alidly writable indices for \textsc{pvm} \textsc{ram} $\memory$. See appendix \ref{sec:virtualmachine}.
   \item[$\edsignature{k}{m}$] The set of $\mathbb{V}$alid Ed25519 signatures of the key $k$ and message $m$. A subset of $\blob[64]$. See section \ref{sec:cryptography}.
-  \item[$\bssignature{k}{c}{m}$] The set of $\mathbb{V}$alid Bandersnatch signatures of the public key $k$, context $c$ and message $m$. A subset of $\blob[64]$. See section \ref{sec:cryptography}.
-  \item[$\bsringproof{r}{c}{m}$] The set of $\mathbb{V}$alid Bandersnatch Ring\textsc{vrf} proofs of the root $r$, context $c$ and message $m$. See section \ref{sec:cryptography}.
+  \item[$\bssignature{k}{c}{m}$] The set of $\mathbb{V}$alid Bandersnatch signatures of the public key $k$, context $c$ and message $m$. A subset of $\blob[96]$. See section \ref{sec:cryptography}.
+  \item[$\bsringproof{r}{c}{m}$] The set of $\mathbb{V}$alid Bandersnatch Ring\textsc{vrf} proofs of the root $r$, context $c$ and message $m$. A subset of $\blob[784]$. See section \ref{sec:cryptography}.
   \item[$\workitem$] The set of $\mathbb{W}$ork items. See equation \ref{eq:workitem}.
   \item[$\defxfer$] The set of deferred transfers.
   \item[$\avspec$] The set of availability specifications.


### PR DESCRIPTION
Bandersnatch signatures are 96 octets, as described in:
https://github.com/gavofyork/graypaper/blob/69d3f5fd17dbcde4b39fab8f7f5588dc14a7a9bc/text/notation.tex#L165
https://github.com/gavofyork/graypaper/blob/69d3f5fd17dbcde4b39fab8f7f5588dc14a7a9bc/text/bandersnatch.tex#L8 