### PR TITLE
Reporting&Assurance: update guarantor assignments to contain full validator keys

### DIFF
--- a/text/reporting_assurance.tex
+++ b/text/reporting_assurance.tex
@@ -200,9 +200,9 @@ This value is utilized in the definition of both $\accountspost$ and $\reportspo
 
 \subsection{Guarantor Assignments}\label{sec:coresandvalidators}
 
-Every block, each core has three validators uniquely assigned to guarantee work-reports for it. This is borne out with $\Cvalcount = 1,023$ validators and $\Ccorecount = 341$ cores, since $\nicefrac{\Cvalcount}{\Ccorecount} = 3$. The core index assigned to each of the validators, as well as the validators' Ed25519 keys are denoted by $\guarantorassignments$:
+Every block, each core has three validators uniquely assigned to guarantee work-reports for it. This is borne out with $\Cvalcount = 1,023$ validators and $\Ccorecount = 341$ cores, since $\nicefrac{\Cvalcount}{\Ccorecount} = 3$. The core index assigned to each of the validators, as well as the validators' keys are denoted by $\guarantorassignments$:
 \begin{equation}
-  \guarantorassignments \in \tuple{\sequence[\Cvalcount]{\coreindex}, \sequence[\Cvalcount]{\edkey}}
+  \guarantorassignments \in \tuple{\sequence[\Cvalcount]{\coreindex}, \allvalkeys}
 \end{equation}
 
 We determine the core to which any given validator is assigned through a shuffle using epochal entropy and a periodic rotation to help guard the security and liveness of the network. We use $\entropy_2$ for the epochal entropy rather than $\entropy_1$ to avoid the possibility of fork-magnification where uncertainty about chain state at the end of an epoch could give rise to two established forks before it naturally resolves.


### PR DESCRIPTION
Currently, guarantor assignments type definition includes guarantors' Ed25519 keys:
<img width="393" alt="Screenshot 2025-06-27 at 12 22 34 AM" src="https://github.com/user-attachments/assets/4d593d7c-31e4-4007-8b4c-4e48b1dcb8f7" />

This PR suggests updating this type to full validator keys:
<img width="395" alt="Screenshot 2025-06-27 at 12 26 03 AM" src="https://github.com/user-attachments/assets/b41d7d14-e533-4e7f-a350-f9f0c476b3ce" />

In the following equations, `Φ(κ′)` or `Φ(λ′)` are used to define the second element of the tuple, which are of full validator key types after nullifying offenders:
<img width="422" alt="Screenshot 2025-06-26 at 9 59 48 PM" src="https://github.com/user-attachments/assets/045eb680-ef56-480d-9c5c-b4db65add9c9" />
<img width="528" alt="Screenshot 2025-06-26 at 11 48 25 PM" src="https://github.com/user-attachments/assets/7dc9ad0e-4f62-4000-b4a7-cb6e1b943598" />
<img width="577" alt="Screenshot 2025-06-27 at 12 16 46 AM" src="https://github.com/user-attachments/assets/572354ad-4f3e-427f-adce-c48220ce689e" />

Also, `e` subscript on **k**_v in the following equation implies that the guarantor assignments contain the full validator keys rather than ed25519 keys:
<img width="647" alt="Screenshot 2025-06-26 at 9 59 32 PM" src="https://github.com/user-attachments/assets/c9877bd3-19aa-4387-b7c1-dad4f1ff6dae" />

An alternative could be to modify eq. `11.21` & `11.22` to explicitly extract Ed25519 keys or add a variant of the key nullifier function `Φ`, while keeping the original type definition with Ed25519 keys.