### PR TITLE
Correct erasure coding equations

### DIFF
--- a/text/erasure_coding.tex
+++ b/text/erasure_coding.tex
@@ -70,7 +70,7 @@ x^{16} + x^5 + x^3 + x^2 + 1
 
 Hence:
 \begin{equation}
-\finitefield_{2^{16}} \equiv \frac{\finitefield_2\subb{x}}{x^{16}} + x^5 + x^3 + x^2 + 1
+\finitefield_{2^{16}} \equiv \frac{\finitefield_2\subb{x}}{x^{16} + x^5 + x^3 + x^2 + 1}
 \end{equation}
 
 We name the generator of $\frac{\finitefield_{2^{16}}}{\finitefield_2}$, the root of the above polynomial, $\authpool$ as such: $\finitefield_{2^{16}} = \finitefield_2(\authpool)$.


### PR DESCRIPTION
This PR suggests correcting several equations in the erasure coding section.

## 1. Consistent Finite Field Order Notation
(before)
<img width="365" alt="F" src="https://github.com/user-attachments/assets/084e391b-843f-4319-99f0-c7cbef9e85f2" />

(after)
<img width="358" alt="F_" src="https://github.com/user-attachments/assets/e40388fd-dab8-4ab9-9a38-caa66cafffe5" />

- For consistency and clarity, updated finite fields to be subscripted with 2^16 instead of 16 in `Eq H.7` and the following description. In other parts it is already correctly written as `GF(2^16)` and `F_2^16`.

## 2. Finite Field Construction Equation (Eq H.7)
(before)
<img width="279" alt="finite" src="https://github.com/user-attachments/assets/5409cd80-fb14-4d0c-9f32-c7d51ce230fb" />

(after)
<img width="265" alt="finite_" src="https://github.com/user-attachments/assets/2375952e-6339-4d0d-8232-b1bb3efd9326" />

- In order to construct finite field of order 2^16, the entire irreducible polynomial should be the modulus - probably a typo.

## 3. `\ecrecover` recovery function rendering issues
(before)
<img width="300" alt="R0" src="https://github.com/user-attachments/assets/acc512b3-697b-48eb-a29d-d138c25d9bbb" />
<img width="470" alt="R" src="https://github.com/user-attachments/assets/c4bd938e-fc40-4cad-ab67-501c5b2655eb" />

(after)
<img width="300" alt="R0_" src="https://github.com/user-attachments/assets/a4372d4e-9fd0-4b0b-b06b-998ca948f90b" />
<img width="468" alt="R_" src="https://github.com/user-attachments/assets/b7204330-d338-4f2b-8204-c5c1e678caed" />

- Updated the description to use `\fnecrecover` instead of `\ecrecover`, since the macro (`\ecrecover`) renders redundant parenthesis.
- Updated `Eq H.5` to put the args into the recover function.