### PR TITLE
PVM Invocations: Add deferred transfers amount to accumulating account balance

### DIFF
--- a/text/pvm_invocations.tex
+++ b/text/pvm_invocations.tex
@@ -137,6 +137,7 @@ We track both regular and exceptional dimensions within our context mutator, but
 
 We define $\Psi_A$, the Accumulation invocation function as:
 \newcommand*{\local¬basestate}{\ao¬poststate}
+\newcommand*{\local¬basestatebalanceadded}{\mathbf{s}}
 \begin{align}
   \label{eq:accinvocation}
   \Psi_A& \colon\abracegroup{
@@ -147,16 +148,23 @@ We define $\Psi_A$, the Accumulation invocation function as:
     \\
     \tup{\local¬basestate, t, s, g, \mathbf{o}} &\mapsto \begin{cases}
       \tup{
-        \ao¬poststate,
+        \is{\ao¬poststate}{\local¬basestatebalanceadded},
         \is{\ao¬defxfers}{\sq{}},
         \is{\ao¬yield}{\none},
         \is{\ao¬gasused}{0},
         \is{\ao¬provisions}{\sq{}}
       }
         &\when \mathbf{c} = \none \vee \len{\mathbf{c}} > \Cmaxservicecodesize \\
-      C(\Psi_M(\mathbf{c}, 5, g, \encode{t, s, \len{\mathbf{o}}}, F, I(\local¬basestate, s)^2))
+      C(\Psi_M(\mathbf{c}, 5, g, \encode{t, s, \len{\mathbf{o}}}, F, I(\local¬basestatebalanceadded, s)^2))
         &\otherwise \\
-      \where \mathbf{c} = \local¬basestate_\ps¬accounts\subb{s}_\sa¬code&
+      \begin{aligned}
+        &\quad\where \mathbf{c} = \local¬basestate_\ps¬accounts\subb{s}_\sa¬code\\
+        &\quad\also \local¬basestatebalanceadded = \local¬basestate \exc \local¬basestatebalanceadded_\ps¬accounts\subb{s}_\sa¬balance = \local¬basestate_\ps¬accounts\subb{s}_\sa¬balance + \sum_{r \in \mathbf{x}}r_\dx¬amount\\
+        &\quad\also \mathbf{x} = \sq{\build{o}{
+          o \orderedin \mathbf{o} ,
+          o \in \defxfer
+        }}
+      \end{aligned}\\
     \end{cases} \\
   }\\
   I&\colon\abracegroup{

--- a/text/pvm_invocations.tex
+++ b/text/pvm_invocations.tex
@@ -146,7 +146,7 @@ We define $\Psi_A$, the Accumulation invocation function as:
     }
     &\to \acconeout
     \\
-    \tup{\local¬basestate, t, s, g, \mathbf{o}} &\mapsto \begin{cases}
+    \tup{\local¬basestate, t, s, g, \mathbf{i}} &\mapsto \begin{cases}
       \tup{
         \is{\ao¬poststate}{\local¬basestatebalanceadded},
         \is{\ao¬defxfers}{\sq{}},
@@ -155,14 +155,14 @@ We define $\Psi_A$, the Accumulation invocation function as:
         \is{\ao¬provisions}{\sq{}}
       }
         &\when \mathbf{c} = \none \vee \len{\mathbf{c}} > \Cmaxservicecodesize \\
-      C(\Psi_M(\mathbf{c}, 5, g, \encode{t, s, \len{\mathbf{o}}}, F, I(\local¬basestatebalanceadded, s)^2))
+      C(\Psi_M(\mathbf{c}, 5, g, \encode{t, s, \len{\mathbf{i}}}, F, I(\local¬basestatebalanceadded, s)^2))
         &\otherwise \\
       \begin{aligned}
         &\quad\where \mathbf{c} = \local¬basestate_\ps¬accounts\subb{s}_\sa¬code\\
         &\quad\also \local¬basestatebalanceadded = \local¬basestate \exc \local¬basestatebalanceadded_\ps¬accounts\subb{s}_\sa¬balance = \local¬basestate_\ps¬accounts\subb{s}_\sa¬balance + \sum_{r \in \mathbf{x}}r_\dx¬amount\\
-        &\quad\also \mathbf{x} = \sq{\build{o}{
-          o \orderedin \mathbf{o} ,
-          o \in \defxfer
+        &\quad\also \mathbf{x} = \sq{\build{i}{
+          i \orderedin \mathbf{i} ,
+          i \in \defxfer
         }}
       \end{aligned}\\
     \end{cases} \\

--- a/text/pvm_invocations.tex
+++ b/text/pvm_invocations.tex
@@ -137,7 +137,7 @@ We track both regular and exceptional dimensions within our context mutator, but
 
 We define $\Psi_A$, the Accumulation invocation function as:
 \newcommand*{\local¬basestate}{\ao¬poststate}
-\newcommand*{\local¬basestatebalanceadded}{\mathbf{s}}
+\newcommand*{\local¬postxferstate}{\mathbf{s}}
 \begin{align}
   \label{eq:accinvocation}
   \Psi_A& \colon\abracegroup{
@@ -148,18 +148,18 @@ We define $\Psi_A$, the Accumulation invocation function as:
     \\
     \tup{\local¬basestate, t, s, g, \mathbf{i}} &\mapsto \begin{cases}
       \tup{
-        \is{\ao¬poststate}{\local¬basestatebalanceadded},
+        \is{\ao¬poststate}{\local¬postxferstate},
         \is{\ao¬defxfers}{\sq{}},
         \is{\ao¬yield}{\none},
         \is{\ao¬gasused}{0},
         \is{\ao¬provisions}{\sq{}}
       }
         &\when \mathbf{c} = \none \vee \len{\mathbf{c}} > \Cmaxservicecodesize \\
-      C(\Psi_M(\mathbf{c}, 5, g, \encode{t, s, \len{\mathbf{i}}}, F, I(\local¬basestatebalanceadded, s)^2))
+      C(\Psi_M(\mathbf{c}, 5, g, \encode{t, s, \len{\mathbf{i}}}, F, I(\local¬postxferstate, s)^2))
         &\otherwise \\
       \begin{aligned}
         &\quad\where \mathbf{c} = \local¬basestate_\ps¬accounts\subb{s}_\sa¬code\\
-        &\quad\also \local¬basestatebalanceadded = \local¬basestate \exc \local¬basestatebalanceadded_\ps¬accounts\subb{s}_\sa¬balance = \local¬basestate_\ps¬accounts\subb{s}_\sa¬balance + \sum_{r \in \mathbf{x}}r_\dx¬amount\\
+        &\quad\also \local¬postxferstate = \local¬basestate \exc \local¬postxferstate_\ps¬accounts\subb{s}_\sa¬balance = \local¬basestate_\ps¬accounts\subb{s}_\sa¬balance + \sum_{r \in \mathbf{x}}r_\dx¬amount\\
         &\quad\also \mathbf{x} = \sq{\build{i}{
           i \orderedin \mathbf{i} ,
           i \in \defxfer


### PR DESCRIPTION
In `on_transfer`, deferred transfer amounts were added to transfer destination accounts' balance prior to invoking `Ψ_M`.
After merging `on_transfer` invocation into `accumulate`, the same process should be handled in the `accumulate` invocation.

<img width="893" height="146" alt="Screenshot 2025-07-19 at 1 22 27 PM" src="https://github.com/user-attachments/assets/d506770e-a50e-4843-89c0-4f4c823b710c" />
(before)

<img width="946" height="214" alt="Screenshot 2025-07-19 at 1 22 48 PM" src="https://github.com/user-attachments/assets/0eb752ff-b0d7-4e1c-8f15-ba4e096a0408" />
(after)