### PR TITLE
fix: remove core index from guarantee payload

### DIFF
--- a/text/guaranteeing.tex
+++ b/text/guaranteeing.tex
@@ -21,7 +21,7 @@ For any guarantor of index $v$ assigned to core $c$ and a work-package $p$, we d
 
 Such guarantors may safely create and distribute the payload $\tup{s, v}$. The component $s$ may be created according to equation \ref{eq:guarantorsig}; specifically it is a signature using the validator's registered Ed25519 key on a payload $l$:
 \begin{equation}
-  l = \blake{\encode{c, r}}
+  l = \blake{\encode{r}}
 \end{equation}
 
 To maximize profit, the guarantor should require the work-digest meets all expectations which are in place during the guarantee extrinsic described in section \ref{sec:workreportguarantees}. This includes contextual validity and inclusion of the authorization in the authorization pool. No doing so does not result in punishment, but will prevent the block author from including the package and so reduces rewards.


### PR DESCRIPTION
In Section 11, [Eqn 11.26](https://graypaper.fluffylabs.dev/#/38c4e62/158c0115e401?v=0.7.0) w.r.t GP 0.7.0,

Payload, on which guarantee is checked, is only report along with its signing context.

However in Section 15, [Eqn 15.2](https://graypaper.fluffylabs.dev/#/38c4e62/1d5e001d7300?v=0.7.0) w.r.t GP 0.7.0,

Payload, which guarantors use, includes both report and core index. Core index here is absolutely unnecessary as report already has core index in it.

This inconsistency might lead to block invalidity in state transition function.