### PR TITLE
Order lastaccout before assign to new state

### DIFF
--- a/text/accumulation.tex
+++ b/text/accumulation.tex
@@ -360,7 +360,7 @@ Given the result of the top-level $\accseq$, we may define the posterior state $
   &\tup{
     \local¬numberofreportsaccumulated, \psX', \mathbf{b}, \local¬servicegasused
   } \equiv \accseq(g, \sq{}, \justbecameavailable^*, \psX, \alwaysaccers) \\
-  &\lastaccout' \equiv \sqorderby{s}{\tup{s, h} \in \mathbf{b}} \\
+  &\lastaccout' \equiv \sq{\tup{s, h} \in \mathbf{b}} \\
   \label{eq:accountspostaccdef}
   &\tup{
     \is\ps¬accounts{\accountspostacc},

--- a/text/accumulation.tex
+++ b/text/accumulation.tex
@@ -358,9 +358,9 @@ Given the result of the top-level $\accseq$, we may define the posterior state $
   \!\!\!\!\!\\
   \label{eq:finalstateaccumulation}
   &\tup{
-    \local¬numberofreportsaccumulated, \psX', b, \local¬servicegasused
+    \local¬numberofreportsaccumulated, \psX', \mathbf{b}, \local¬servicegasused
   } \equiv \accseq(g, \sq{}, \justbecameavailable^*, \psX, \alwaysaccers) \\
-  &\lastaccout' \equiv \sqorderby{s}{\tup{s, h} \in b} \\
+  &\lastaccout' \equiv \sqorderby{s}{\tup{s, h} \in \mathbf{b}} \\
   \label{eq:accountspostaccdef}
   &\tup{
     \is\ps¬accounts{\accountspostacc},

--- a/text/accumulation.tex
+++ b/text/accumulation.tex
@@ -358,8 +358,9 @@ Given the result of the top-level $\accseq$, we may define the posterior state $
   \!\!\!\!\!\\
   \label{eq:finalstateaccumulation}
   &\tup{
-    \local¬numberofreportsaccumulated, \psX', \lastaccout', \local¬servicegasused
+    \local¬numberofreportsaccumulated, \psX', b, \local¬servicegasused
   } \equiv \accseq(g, \sq{}, \justbecameavailable^*, \psX, \alwaysaccers) \\
+  &\lastaccout' \equiv \sqorderby{s}{\tup{s, h} \in b} \\
   \label{eq:accountspostaccdef}
   &\tup{
     \is\ps¬accounts{\accountspostacc},


### PR DESCRIPTION
add the missing ordering for last accumulation output

the last accumulation output type is sequence in 
<img width="251" height="35" alt="image" src="https://github.com/user-attachments/assets/be01f740-2adb-4cf4-b8bc-451ab1568081" />

and outer accumulate returns B which is a set

<img width="438" height="174" alt="image" src="https://github.com/user-attachments/assets/fa77e1d6-818a-46a5-8031-0e6bc71a4dea" />
<img width="429" height="46" alt="image" src="https://github.com/user-attachments/assets/fbcb6ce2-dd86-472d-b8e1-429892ebccef" />

-------
Changes

- before:

<img width="490" height="269" alt="image" src="https://github.com/user-attachments/assets/974c349b-1148-40c2-851c-428f2bbf1a81" />


- after:

<img width="444" height="293" alt="image" src="https://github.com/user-attachments/assets/cf08cb96-7701-4759-89d4-f6eeb9164f0f" />
