### PR TITLE
Assign registers 9 and 10 to *f* and *l* in info host call

### DIFF
--- a/text/pvm_invocations.tex
+++ b/text/pvm_invocations.tex
@@ -464,8 +464,8 @@ Other than the gas-counter which is explicitly defined, elements of \textsc{pvm}
       } &\when \mathbf{a} \ne \none \\
       \none &\otherwise
     \end{cases} \\
-    \using f &= \min(\registers_{11}, \len{\mathbf{v}}) \\
-    \using l &= \min(\registers_{12}, \len{\mathbf{v}} - f) \\
+    \using f &= \min(\registers_{9}, \len{\mathbf{v}}) \\
+    \using l &= \min(\registers_{10}, \len{\mathbf{v}} - f) \\
     \tup{\execst', \registers'_7, \memory'\subrange{o}{l}} &\equiv \begin{cases}
       \tup{\panic, \registers_7, \memory\subrange{o}{l}} &\when \mathbf{v} = \error \vee \Nrange{o}{l} \not\subseteq \writable{\memory}\\
       \tup{\continue, \mathtt{NONE}, \memory\subrange{o}{l}} &\otherwhen \mathbf{v} = \none \\


### PR DESCRIPTION
All host calls assign arguments to sequential registers, except for the `info` host call, which currently uses `s = 7`, `o = 8`, `f = 11`, and `l = 12`.  

This PR changes `f` and `l` to use registers `9` and `10`, respectively.
