### PR TITLE
Serialization: Correct bit sequence encoding range

### DIFF
--- a/text/serialization.tex
+++ b/text/serialization.tex
@@ -67,7 +67,7 @@ A sequence of bits $b \in \bitstring$ is a special case since encoding each indi
   \encode{b \in \bitstring} &\equiv \begin{cases}
     \sq{} &\when b = \sq{} \\
     \sq{
-      \sum\limits_{i=0}^{\min(8, \len{b})}
+      \sum\limits_{i=0}^{\min(8, \len{b}) - 1}
       b\sub{i} \cdot 2^i
     } \concat \encode{b\interval{8}{}} &\otherwise\\
   \end{cases}

--- a/text/serialization.tex
+++ b/text/serialization.tex
@@ -67,7 +67,7 @@ A sequence of bits $b \in \bitstring$ is a special case since encoding each indi
   \encode{b \in \bitstring} &\equiv \begin{cases}
     \sq{} &\when b = \sq{} \\
     \sq{
-      \sum\limits_{i=0}^{\min(8, \len{b}) - 1}
+      \sum\limits_{i=0}^{i < \min(8, \len{b})}
       b\sub{i} \cdot 2^i
     } \concat \encode{b\interval{8}{}} &\otherwise\\
   \end{cases}


### PR DESCRIPTION
In general, the Sigma sum notation (∑) uses inclusive start/end ranges. Other equations in GP follow this rule, e.g. [PVM instruction 102 & 103](https://graypaper.fluffylabs.dev/#/1c979cb/282102282102?v=0.7.1) and [Eq (H.9)](https://graypaper.fluffylabs.dev/#/1c979cb/3f71023f7102?v=0.7.1).

Updated bit sequence encoding function to follow this convention as well, ensuring it properly extracts 8 bits at once.