### PR TITLE
Simplify fetch case 8

### DIFF
--- a/text/pvm_invocations.tex
+++ b/text/pvm_invocations.tex
@@ -341,7 +341,7 @@ Other than the gas-counter which is explicitly defined, elements of \textsc{pvm}
       \overline{\mathbf{i}}[\registers_{11}]_{\registers_{12}} &\when \overline{\mathbf{i}} \ne \none \wedge \registers_{10} = 5 \wedge \registers_{11} < \len{\overline{\mathbf{i}}} \wedge \registers_{12} < \len{\overline{\mathbf{i}}[\registers_{11}]} \\
       \overline{\mathbf{i}}\subb{i}_{\registers_{11}} &\when \overline{\mathbf{i}} \ne \none \wedge i \ne \none \wedge \registers_{10} = 6 \wedge \registers_{11} < \len{\overline{\mathbf{i}}\subb{i}} \\
       \encode{p} &\when p \ne \none \wedge \registers_{10} = 7 \\
-      \encode{p_\wp¬authcodehash, \var{p_\wp¬authconfig}} &\when p \ne \none \wedge \registers_{10} = 8 \\
+      p_\wp¬authconfig &\when p \ne \none \wedge \registers_{10} = 8 \\
       p_\wp¬authtoken &\when p \ne \none \wedge \registers_{10} = 9 \\
       \encode{p_\wp¬context} &\when p \ne \none \wedge \registers_{10} = 10 \\
       \encode{\var{\sq{\build{S(w)}{w \orderedin p_\wp¬workitems}}}} &\when p \ne \none \wedge \registers_{10} = 11 \\


### PR DESCRIPTION
Just return configuration blob. The code hash is at a fixed location in the work-package and can be trivially read via case 7 if needed.