### PR TITLE
PVM Invocations: Correct gas charge for `TRANSFER` host call failures

### DIFF
--- a/text/pvm_invocations.tex
+++ b/text/pvm_invocations.tex
@@ -813,7 +813,7 @@ Other than the gas-counter which is explicitly defined, elements of \textsc{pvm}
   \makecell*[l]{
   $\Omega_T(\gascounter, \registers, \memory, \imXY)$ \\
   \texttt{transfer} = 20 \\
-  $g = 10 + \registers_9 $} &
+  $g = 10 + t$} &
   $\begin{aligned}
     \using \sq{\dx¬dest, \dx¬amount, l, o} &= \registers\subrange{7}{4},  \\
     \using \mathbf{d} &= (\imX_\im¬state)_\ps¬accounts\\
@@ -827,12 +827,17 @@ Other than the gas-counter which is explicitly defined, elements of \textsc{pvm}
       } &\when \Nrange{o}{\Cmemosize} \subseteq \readable{\memory} \\
       \error &\otherwise
     \end{cases} \\
+    \using \tup{c, t} &= \begin{cases}
+      \tup{\panic, 0} &\when \mathbf{t} = \error \\
+      \tup{\mathtt{WHO}, 0} &\otherwhen \dx¬dest \not \in \keys{\mathbf{d}} \\
+      \tup{\mathtt{LOW}, 0} &\otherwhen l < \mathbf{d}[\dx¬dest]_\sa¬minmemogas \\
+      \tup{\mathtt{CASH}, 0} &\otherwhen \dx¬amount < (\imX_\im¬self)_\sa¬minbalance \\
+      \tup{\mathtt{OK}, l} &\otherwise
+    \end{cases} \\
     \using b &= (\imX_\im¬self)_\sa¬balance - \dx¬amount \\
     \tup{\execst', \registers'_7, \imX'_\im¬xfers, (\imX'_\im¬self)_\sa¬balance} &\equiv \begin{cases}
-      \tup{\panic, \registers_7, \imX_\im¬xfers, (\imX_\im¬self)_\sa¬balance} &\when \mathbf{t} = \error \\
-      \tup{\continue, \mathtt{WHO}, \imX_\im¬xfers, (\imX_\im¬self)_\sa¬balance} &\otherwhen \dx¬dest \not \in \keys{\mathbf{d}} \\
-      \tup{\continue, \mathtt{LOW}, \imX_\im¬xfers, (\imX_\im¬self)_\sa¬balance} &\otherwhen l < \mathbf{d}[\dx¬dest]_\sa¬minmemogas \\
-      \tup{\continue, \mathtt{CASH}, \imX_\im¬xfers, (\imX_\im¬self)_\sa¬balance} &\otherwhen \dx¬amount < (\imX_\im¬self)_\sa¬minbalance \\
+      \tup{\panic, \registers_7, \imX_\im¬xfers, (\imX_\im¬self)_\sa¬balance} &\when c = \panic \\
+      \tup{\continue, c, \imX_\im¬xfers, (\imX_\im¬self)_\sa¬balance} &\otherwhen c \ne \mathtt{OK} \\
       \tup{\continue, \mathtt{OK}, \imX_\im¬xfers \append \mathbf{t}, b} &\otherwise
     \end{cases} \\
   \end{aligned}$\\


### PR DESCRIPTION
Currently, `TRANSFER` host call charges additional gas `φ9` for all failure cases (`Panic`, `WHO`, `LOW`, `CASH`). 
However, for those cases, only the base gas `g = 10` should be charged since the additional gas is for covering the cost for processing deferred transfers. The failure cases do not add a deferred transfer to the accumulate context (**x**_**t**).

This PR corrects this by refactoring the logic to determine the host call result first, then the total gas charge. 
Two local variables are introduced: `c` for host call result code and `t` for transfer gas limit.

(before)
<img width="703" height="279" alt="xfer_before" src="https://github.com/user-attachments/assets/346e88e2-5088-4c4d-b396-54287f0f42bd" />

(after)
<img width="672" height="343" alt="xfer_after" src="https://github.com/user-attachments/assets/2c0ced20-53cc-4a87-b53b-5202e277cca8" />