### PR TITLE
PVM Invocations: Fix `transfer` typo

### DIFF
--- a/text/pvm_invocations.tex
+++ b/text/pvm_invocations.tex
@@ -827,14 +827,14 @@ Other than the gas-counter which is explicitly defined, elements of \textsc{pvm}
       } &\when \Nrange{o}{\Cmemosize} \subseteq \readable{\memory} \\
       \error &\otherwise
     \end{cases} \\
+    \using b &= (\imX_\im¬self)_\sa¬balance - \dx¬amount \\
     \using \tup{c, t} &= \begin{cases}
       \tup{\panic, 0} &\when \mathbf{t} = \error \\
       \tup{\mathtt{WHO}, 0} &\otherwhen \dx¬dest \not \in \keys{\mathbf{d}} \\
       \tup{\mathtt{LOW}, 0} &\otherwhen l < \mathbf{d}[\dx¬dest]_\sa¬minmemogas \\
-      \tup{\mathtt{CASH}, 0} &\otherwhen \dx¬amount < (\imX_\im¬self)_\sa¬minbalance \\
+      \tup{\mathtt{CASH}, 0} &\otherwhen b < (\imX_\im¬self)_\sa¬minbalance \\
       \tup{\mathtt{OK}, l} &\otherwise
     \end{cases} \\
-    \using b &= (\imX_\im¬self)_\sa¬balance - \dx¬amount \\
     \tup{\execst', \registers'_7, \imX'_\im¬xfers, (\imX'_\im¬self)_\sa¬balance} &\equiv \begin{cases}
       \tup{\panic, \registers_7, \imX_\im¬xfers, (\imX_\im¬self)_\sa¬balance} &\when c = \panic \\
       \tup{\continue, c, \imX_\im¬xfers, (\imX_\im¬self)_\sa¬balance} &\otherwhen c \ne \mathtt{OK} \\


### PR DESCRIPTION
Closes https://github.com/gavofyork/graypaper/issues/489