### PR TITLE
Some trivial PVM fixes

### DIFF
--- a/text/pvm.tex
+++ b/text/pvm.tex
@@ -255,7 +255,7 @@ Similarly, conditional jumps are valid if and only if both branches point to the
 \begin{equation}
   \token{branch}(b, C) \implies \tup{\varepsilon, \imath'} = \begin{cases}
     \tup{\panic, \imath} &\when b \not\in \basicblocks \lor \imath + 1 + \text{skip}(\imath) \not\in \basicblocks \\
-    \tup{\continue, \imath} &\otherwhen \lnot C \\
+    \tup{\continue, \imath + 1 + \Fskip(\imath)} &\otherwhen \lnot C \\
     \tup{\continue, b} &\otherwise
   \end{cases}
 \end{equation}

--- a/text/pvm_invocations.tex
+++ b/text/pvm_invocations.tex
@@ -571,7 +571,7 @@ These assume some refine context pair $\tup{\mathbf{m}, \mathbf{e}} \in \tuple{\
     \using p &= \registers_7 \\
     \using z &= \min(\registers_8, \Csegmentsize) \\
     \using \mathbf{x} &= \begin{cases}
-      \zeropad{\Csegmentsize}{\mem\subrange{p}{z}} &\when \Nrange{p}{z} \subseteq \readable[\memory]\\
+      \zeropad{\Csegmentsize}{\mem\subrange{p}{z}} &\when \Nrange{p}{z} \subseteq \readable{\memory}\\
       \error &\otherwise
     \end{cases}\\
     \tup{\execst', \registers'_7, \mathbf{e}'} &\equiv \begin{cases}
@@ -607,7 +607,7 @@ These assume some refine context pair $\tup{\mathbf{m}, \mathbf{e}} \in \tuple{\
   $\begin{aligned}
     \using \sq{n, o, s, z} &= \registers\subrange{7}{4} \\
     \tup{\execst', \registers'_7, \mem'} &\equiv \begin{cases}
-      \tup{\panic, \registers_7, \mem} &\when \Nrange{o}{z} \not\subseteq \writable[\memory] \\
+      \tup{\panic, \registers_7, \mem} &\when \Nrange{o}{z} \not\subseteq \writable{\memory} \\
       \tup{\continue, \mathtt{WHO}, \mem} &\otherwhen n \not\in \keys{\mathbf{m}} \\
       \tup{\continue, \mathtt{OOB}, \mem} &\otherwhen \Nrange{s}{z} \not\subseteq \readable{\mathbf{m}\subb{n}_\pg¬ram} \\
       \tup{\continue, \mathtt{OK}, \mem'} &\otherwise \\
@@ -622,7 +622,7 @@ These assume some refine context pair $\tup{\mathbf{m}, \mathbf{e}} \in \tuple{\
   $\begin{aligned}
     \using \sq{n, s, o, z} &= \registers\subrange{7}{4} \\
     \tup{\execst', \registers'_7, \mathbf{m}'} &\equiv \begin{cases}
-      \tup{\panic, \registers_7, \mathbf{m}} &\when \Nrange{s}{z} \not\subseteq \readable[\memory] \\
+      \tup{\panic, \registers_7, \mathbf{m}} &\when \Nrange{s}{z} \not\subseteq \readable{\memory} \\
       \tup{\continue, \mathtt{WHO}, \mathbf{m}} &\otherwhen n \not\in \keys{\mathbf{m}} \\
       \tup{\continue, \mathtt{OOB}, \mathbf{m}} &\otherwhen \Nrange{o}{z} \not\subseteq \writable{\mathbf{m}\subb{n}_\pg¬ram} \\
       \tup{\continue, \mathtt{OK}, \mathbf{m}'}  &\otherwise \\

--- a/text/pvm_invocations.tex
+++ b/text/pvm_invocations.tex
@@ -675,7 +675,7 @@ These assume some refine context pair $\tup{\mathbf{m}, \mathbf{e}} \in \tuple{\
     \using \mathbf{m}^* &= \mathbf{m} \exc \begin{cases}
       \mathbf{m}^*\subb{n}_\pg¬ram = \mathbf{u}'\\
       \mathbf{m}^*\subb{n}_\pg¬pc = \begin{cases}
-        i' + \Fskip(\imath') + 1 &\when c \in \set{ \host } \times \pvmreg\\
+        i' + \Fskip(i') + 1 &\when c \in \set{ \host } \times \pvmreg\\
         i' &\otherwise
       \end{cases}\\
       \mathbf{m}^*\subb{n}_{\pg¬gaschargedflag} = \pg¬gaschargedflag'\\


### PR DESCRIPTION
- Fix a variable reference.
- Advance over untaken branch instructions. Not sure if this should also be done in the panic case.
- Fix some macro invocations (square -> curly brackets).