### PR TITLE
Account gas for memory access

### DIFF
--- a/text/pvm.tex
+++ b/text/pvm.tex
@@ -141,8 +141,8 @@ Formally, let $\mathbf{r}$ and $\mathbf{w}$ be the set of indices by which $\mem
   \using \mathbf{x} &= \set{\build{x}{x \in \mathbf{r} \wedge x \bmod 2^{32} \not\in \readable\mem\ \vee\ x \in \mathbf{w} \wedge x \bmod 2^{32} \not\in \writable\mem}} \\
   \tup{\varepsilon^*, \imath^*, \gascounter^*, \registers^*, \mem^*} &= \begin{cases}
     \tup{\varepsilon, \imath', \gascounter', \registers', \mem'} &\when \mathbf{x} = \emset \\
-    \tup{\panic, \imath, \gascounter, \registers, \mem} &\when \min(\mathbf{x}) \bmod 2^{32} < 2^{16} \\
-    \tup{\fault \times \Cpvmpagesize\floor{\min(\mathbf{x}) \bmod 2^{32} \div \Cpvmpagesize}, \imath, \gascounter, \registers, \mem} &\otherwise
+    \tup{\panic, \imath, \gascounter', \registers, \mem} &\when \min(\mathbf{x}) \bmod 2^{32} < 2^{16} \\
+    \tup{\fault \times \Cpvmpagesize\floor{\min(\mathbf{x}) \bmod 2^{32} \div \Cpvmpagesize}, \imath, \gascounter', \registers, \mem} &\otherwise
   \end{cases}
 \end{align}
 


### PR DESCRIPTION
Charging for the instruction that triggered the trap makes sense also according to this statement at the begin of section A.1

> Assuming the program blob is valid (which can be validated statically), some gas is always charged whenever execution
> is attempted. This is the case even if no instruction is effectively executed and machine state is unchanged (i.e. the result
> state is equal to the parameter).

Otherwise no gas is charged if the very first instruction is one that triggers a trap for memory access.

---

Furthermore this is consistent and equivalent to an explicit `trap` instruction, which is charged 1 gas unit.
