### PR TITLE
Add back processed transfer count to service statistics

### DIFF
--- a/text/accumulation.tex
+++ b/text/accumulation.tex
@@ -5,6 +5,7 @@
 \newcommand*{\local¬fnprovide}{I}
 \newcommand*{\local¬numberofreportsaccumulated}{n}
 \newcommand*{\local¬servicegasused}{\mathbf{u}}
+\newcommand*{\local¬processedtransfers}{\mathbf{t}}
 
 \section{Accumulation}
 \label{sec:accumulation}
@@ -149,21 +150,21 @@ Finally, we define $\local¬fnservouts$ and $\local¬fngasused$, the sets charac
   \local¬fngasused \equiv \sequence{\tuple{\serviceid, \gas}}
 \end{equation}
 
-We define the outer accumulation function $\accseq$ which transforms a gas-limit, a sequence of deferred transfers, a sequence of work-reports, an initial partial-state and a dictionary of services enjoying free accumulation, into a tuple of the number of work-reports accumulated, a posterior state-context, the resultant accumulation-output pairings and the service-indexed gas usage:
+We define the outer accumulation function $\accseq$ which transforms a gas-limit, a sequence of deferred transfers, a sequence of work-reports, an initial partial-state and a dictionary of services enjoying free accumulation, into a tuple of the number of work-reports accumulated, a posterior state-context, the resultant accumulation-output pairings, the service-indexed gas usage and the sequence of processed transfers:
 \begin{equation}
   \label{eq:accseq}
   \accseq\colon\abracegroup{
-    &\tuple{\gas, \defxfers, \workreports, \partialstate, \dictionary{\serviceid}{\gas}} \to \tuple{\N, \partialstate, \local¬fnservouts, \local¬fngasused} \\
+    &\tuple{\gas, \defxfers, \workreports, \partialstate, \dictionary{\serviceid}{\gas}} \to \tuple{\N, \partialstate, \local¬fnservouts, \local¬fngasused, \defxfers} \\
     &\tup{g, \mathbf{t}, \mathbf{r}, \psX, \mathbf{f}} \!\mapsto\! \begin{cases}
-      \tup{0, \psX, \emset, \sq{}} &
+      \tup{0, \psX, \emset, \sq{}, \sq{}} &
         \when n = 0 \\
-      \tup{i + j, \psX', \mathbf{b}^* \!\cup \mathbf{b}, \mathbf{u}^* \!\!\concat \mathbf{u}}\!\!\!\! &
+      \tup{i + j, \psX', \mathbf{b}^* \!\cup \mathbf{b}, \mathbf{u}^* \!\!\concat \mathbf{u}, \mathbf{t} \concat \mathbf{t}^\dagger}\!\!\!\! &
         \text{o/w}\!\!\!\!\!\!\!\! \\
     \end{cases} \\
     &\quad\where i = \max(\Nmax{\len{\mathbf{r}} + 1}): \sum_{r \in \mathbf{r}\sub{\dots i}, d \in r_\wr¬digests}(d_\wd¬gaslimit) \le g \\
     &\quad\also n = \len{\mathbf{t}} + i + \len{\mathbf{f}} \\
     &\quad\also \tup{\psX^*\!\!, \mathbf{t}^*\!\!, \mathbf{b}^*\!\!, \mathbf{u}^*} = \accpar(\psX, \mathbf{t},\mathbf{r}\sub{\dots i}, \mathbf{f}) \\
-    &\quad\also \tup{j, \psX'\!, \mathbf{b}, \mathbf{u}} = \accseq(g^* - \!\!\!\!\!\!\sum_{\tup{s, u} \in \mathbf{u}^*}\!\!\!\!\!\!(u), \mathbf{t}^*\!\!, \mathbf{r}\sub{i\dots}, \psX^*\!\!, \emset)\\
+    &\quad\also \tup{j, \psX'\!, \mathbf{b}, \mathbf{u}, \mathbf{t}^\dagger} = \accseq(g^* - \!\!\!\!\!\!\sum_{\tup{s, u} \in \mathbf{u}^*}\!\!\!\!\!\!(u), \mathbf{t}^*\!\!, \mathbf{r}\sub{i\dots}, \psX^*\!\!, \emset)\\
     &\quad\also g^* = g + \sum_{t \in \mathbf{t}}(t_\dx¬gas)
   }
 \end{equation}
@@ -365,7 +366,7 @@ Given the result of the top-level $\accseq$, we may define the posterior state $
   \!\!\!\!\!\\
   \label{eq:finalstateaccumulation}
   &\tup{
-    \local¬numberofreportsaccumulated, \psX', \mathbf{b}, \local¬servicegasused
+    \local¬numberofreportsaccumulated, \psX', \mathbf{b}, \local¬servicegasused, \local¬processedtransfers
   } \equiv \accseq(g, \sq{}, \justbecameavailable^*, \psX, \alwaysaccers) \\
   &\lastaccout' \equiv \sq{\tup{s, h} \in \mathbf{b}} \\
   \label{eq:accountspostaccdef}
@@ -382,24 +383,31 @@ Given the result of the top-level $\accseq$, we may define the posterior state $
   \!\!\!\!\!
 \end{align}
 
-From this formulation, we also receive $\local¬numberofreportsaccumulated$, the total number of work-reports accumulated and $\local¬servicegasused$, the gas used in the accumulation process for each service. We compose $\accumulationstatistics$, our accumulation statistics, which is a mapping from the service indices which were accumulated to the amount of gas used throughout accumulation and the number of work-items accumulated. Formally:
+From this formulation, we also receive $\local¬numberofreportsaccumulated$, the total number of work-reports accumulated and $\local¬servicegasused$, the gas used in the accumulation process for each service. We compose $\accumulationstatistics$, our accumulation statistics, which is a mapping from the service indices which were accumulated to the amount of gas used throughout accumulation and the number of work-items and transfers accumulated. Formally:
 \begin{align}
   \label{eq:accumulationstatisticsspec}
-  &\accumulationstatistics \in \dictionary{\serviceid}{\tuple{\gas, \N}} \\
+  &\accumulationstatistics \in \dictionary{\serviceid}{\tuple{\gas, \N, \N}} \\
   \label{eq:accumulationstatisticsdef}
   &\textstyle \accumulationstatistics \equiv \set{\build{
-    \kv{s}{\tup{G(s), N(s)}}
+    \kv{s}{S(s)}
   }{
-    G(s) + N(s) \ne 0
+    S(s) \ne \tup{0, 0, 0}
   }}
   \!\!\!\!\\
   \nonumber
-  \where &G(s) \equiv \sum_{\tup{s, u} \in \mathbf{u}}(u) \\
+  \where &S(s) \equiv \tup{G(s), N(s), T(s)} \\
+  \nonumber
+  \also &G(s) \equiv \sum_{\tup{s, u} \in \mathbf{u}}(u) \\
   \nonumber
   \also &N(s) \equiv \len{\sq{\build{d}{
     r \orderedin \justbecameavailable^*\sub{\dots n} ,
     d \orderedin r_\wr¬digests ,
     d_\wd¬serviceindex = s
+  }}} \\
+  \nonumber
+  \also &T(s) \equiv \len{\sq{\build{t}{
+    t \orderedin \local¬processedtransfers ,
+    t_\dx¬dest = s
   }}}
 \end{align}
 

--- a/text/accumulation.tex
+++ b/text/accumulation.tex
@@ -386,7 +386,7 @@ Given the result of the top-level $\accseq$, we may define the posterior state $
 From this formulation, we also receive $\local¬numberofreportsaccumulated$, the total number of work-reports accumulated and $\local¬servicegasused$, the gas used in the accumulation process for each service. We compose $\accumulationstatistics$, our accumulation statistics, which is a mapping from the service indices which were accumulated to the amount of gas used throughout accumulation and the number of work-items and transfers accumulated. Formally:
 \begin{align}
   \label{eq:accumulationstatisticsspec}
-  &\accumulationstatistics \in \dictionary{\serviceid}{\tuple{\gas, \N, \N}} \\
+  &\accumulationstatistics \in \dictionary{\serviceid}{\tuple{\N, \N, \gas}} \\
   \label{eq:accumulationstatisticsdef}
   &\textstyle \accumulationstatistics \equiv \set{\build{
     \kv{s}{S(s)}
@@ -395,9 +395,7 @@ From this formulation, we also receive $\local¬numberofreportsaccumulated$, the
   }}
   \!\!\!\!\\
   \nonumber
-  \where &S(s) \equiv \tup{G(s), N(s), T(s)} \\
-  \nonumber
-  \also &G(s) \equiv \sum_{\tup{s, u} \in \mathbf{u}}(u) \\
+  \where &S(s) \equiv \tup{N(s), T(s), G(s)} \\
   \nonumber
   \also &N(s) \equiv \len{\sq{\build{d}{
     r \orderedin \justbecameavailable^*\sub{\dots n} ,
@@ -408,7 +406,9 @@ From this formulation, we also receive $\local¬numberofreportsaccumulated$, the
   \also &T(s) \equiv \len{\sq{\build{t}{
     t \orderedin \local¬processedtransfers ,
     t_\dx¬dest = s
-  }}}
+  }}} \\
+  \nonumber
+  \also &G(s) \equiv \sum_{\tup{s, u} \in \mathbf{u}}(u)
 \end{align}
 
 The second intermediate state $\accountspostxfer$ may then be defined with the last-accumulation record being updated for all accumulated services:

--- a/text/definitions.tex
+++ b/text/definitions.tex
@@ -164,7 +164,7 @@ These terms are all contextualized to a single block. They may be superscripted 
   \item[$\accoutcommitment{v}$] The \textsc{Beefy} signed commitment of validator $v$. See equation \ref{eq:accoutsignedcommitment}.
   \item[$\reporters$] The set of Ed25519 guarantor keys who made a work-report. See equation \ref{eq:guarantorsig}.
   \item[$\header$] The block header. See equation \ref{eq:header}.
-  \item[$\accumulationstatistics$] The sequence of work-reports which were accumulated this in this block. See equations \ref{eq:accumulationstatisticsspec} and \ref{eq:accumulationstatisticsdef}.
+  \item[$\accumulationstatistics$] Service-indexed accumulation statistics for this block. See equations \ref{eq:accumulationstatisticsspec} and \ref{eq:accumulationstatisticsdef}.
   \item[$\guarantorassignments$] The mapping from cores to guarantor keys. See section \ref{sec:coresandvalidators}.
   \item[$\guarantorassignmentsunderlastrotation$] The mapping from cores to guarantor keys for the previous rotation. See section \ref{sec:coresandvalidators}.
   \item[$\justbecameavailable$] The sequence of work-reports which have now become available and ready for accumulation. See equation \ref{eq:availableworkreports}.

--- a/text/statistics.tex
+++ b/text/statistics.tex
@@ -96,7 +96,7 @@ The other two components of statistics are the core and service activity statist
       \isa{\ss¬xtcount}{\N}\,,\;
       \isa{&\ss¬xtsize&}{\N}\,,\;
       \isa{\ss¬exportcount}{\N}\,,\;\\
-      \isa{\ss¬accumulation&}{\tup{\N, \gas}}
+      \isa{\ss¬accumulation&}{\tup{\N, \N, \gas}}
     \end{alignedat}
   }}
 \end{align}

--- a/text/statistics.tex
+++ b/text/statistics.tex
@@ -159,7 +159,7 @@ Finally, the service statistics are updated using the same intermediate values a
       }\,,\;\\
       \is{\ss¬accumulation&}{
         \span\span
-        \subifnone{\accumulationstatistics\subb{s}, \tup{0, 0}}
+        \subifnone{\accumulationstatistics\subb{s}, \tup{0, 0, 0}}
       }
     \end{alignedat}
   }\!\!\!\!\\


### PR DESCRIPTION
This was removed when accumulate was combined with on_transfer. It seems like useful statistic, so add it back.