### PR TITLE
Add fetch case 16 for accumulation: block header

### DIFF
--- a/text/pvm_invocations.tex
+++ b/text/pvm_invocations.tex
@@ -358,7 +358,7 @@ Other than the gas-counter which is explicitly defined, elements of \textsc{pvm}
       p_\wp¬workitems[\registers_{11}]_\wi¬payload &\when p \ne \none \wedge \registers_{10} = 13 \wedge \registers_{11} < \len{p_\wp¬workitems} \\
       \encode{\var{\mathbf{i}}} &\when \mathbf{i} \ne \none \wedge \registers_{10} = 14 \\
       \encode{\mathbf{i}[\registers_{11}]} &\when \mathbf{i} \ne \none \wedge \registers_{10} = 15 \wedge \registers_{11} < \len{\mathbf{i}} \\
-      \encode{\mathbf{H}} &\when p \ne \none \wedge \registers_{10} = 16 \\
+      \encode{\mathbf{H}} &\when \registers_{10} = 16 \\
       \none &\otherwise
     \end{cases} \\
     \using o &= \registers_7 \\


### PR DESCRIPTION
This adds a case 16 to fetch, available for accumulate invocations.   The [whole block header](https://graypaper.fluffylabs.dev/#/ab2cdbd/0c67000c6700?v=0.7.2) is made available for the service to copy whatever it wants from the JAM block header into its own rollup blocks.  This header not only includes the prior state root, but also the parent header hash, extrinsic hash, seal,  block seal, entropy yielding VRF signature, block author index, epoch marker, etc.  

## Motivation: 

The fetch host function does not presently provide access to the JAM parent state root to accumulate invocations, which is the authoritative commitment of everything in JAM State.

A rollup host service would typically be expected to include some kind of state root in a rollup's block for proofs of inclusion, historical lookups, etc., where having the JAM prior state root for each accumulate would be valuable to include in a rollup block.

A rollup host service can have its accumulate invocation use the yield host function or 32-byte accumulate roots to get an ample alternative for a rollup host's commitments going into JAM State C(16).  

However, for backwards compatibility with rollups expectations of a rollup host (eg for historical lookups of any commitment by the rollup against some JAM State root included in the rollups "block"), all the commitments in the JAM block header are made available -- not just the state root but all the attributes.

## Notes

* H_T is redundantly present in both the accumulate argument inputs and in the header; potentially this could be eliminated from the accumulate input, although adding whatever cost the fetch host function 
* H_V provides an additional source of entropy available to the service beyond the one already available from η0' -- but its already included -- see below from @davxy =)

