### PR TITLE
Clarify missing validator-key subscript in auditing and beefy equations

### DIFF
--- a/preamble.tex
+++ b/preamble.tex
@@ -191,7 +191,7 @@
 \newcommand*{\fnzeropad}[1]{\mathcal{P}_{#1}}
 \newcommand*{\fnseqfromhash}[1]{\mathcal{Q}_{#1}}
 \newcommand*{\fnecrecover}{\mathcal{R}}
-\newcommand*{\fnsigndata}[1]{\mathcal{S}_{#1}}
+\newcommand*{\fnsigndata}{\mathcal{S}}
 \newcommand*{\fnsubifnone}{\mathcal{U}}
 \newcommand*{\fnsext}[1]{\mathcal{X}_{#1}}
 \newcommand*{\fnbanderout}{\mathcal{Y}}
@@ -347,9 +347,8 @@
 \newcommand*{\ringroot}{\accentset{\circ}{\blob}}
 \newcommand*{\blskey}{\accentset{\mathrm{B\!L\!S}}{\blob}}
 
-\newcommand*{\edsigndata}[2]{\bar{\fnsigndata{#1}}\left(#2\right)}
-\newcommand*{\bssigndata}[2]{\accentset{\backsim}{\fnsigndata{#1}}\left(#2\right)}
-\newcommand*{\blssigndata}[2]{\accentset{\mathrm{B\!L\!S}}{\fnsigndata{#1}}\left(#2\right)}
+\newcommand*{\edsigndata}[2]{\bar{\fnsigndata}_{#1}\left(#2\right)}
+\newcommand*{\blssigndata}[2]{\accentset{\mathrm{B\!L\!S}}{\fnsigndata}_{#1}\left(#2\right)}
 
 %%%%%%%%%%%%
 % Specialized numeric types (blackboard N subscripts)

--- a/text/auditing.tex
+++ b/text/auditing.tex
@@ -139,7 +139,7 @@ From this mapping the validator issues a set of judgments $\mathbf{j}\sub{n}$:
   \label{eq:judgments}
   \mathbf{j}\sub{n} &= \set{\build{
     \edsigndata{
-      \activeset\subb{v}_\vk¬ed
+      \activeset\subb{v}\sub{\vk¬ed}
     }{
       \Xvalidif{e\sub{n}(\cX)} \concat \blake{\wrX}
     }

--- a/text/beefy.tex
+++ b/text/beefy.tex
@@ -5,6 +5,6 @@ For each finalized block $\block$ which a validator imports, said validator shal
 
 Formally, let $\accoutcommitment{v}$ be the signed commitment of validator index $v$ which will be published:
 \begin{align}\label{eq:accoutsignedcommitment}
-  \accoutcommitment{v} &\equiv \blssigndata{\activeset'\sub{v}}{\Xbeefy \concat \text{last}(\recenthistory)_\rh¬accoutlogsuperpeak}\\
+  \accoutcommitment{v} &\equiv \blssigndata{\activeset'\subb{v}\sub{\vk¬bls}}{\Xbeefy \concat \text{last}(\recenthistory)_\rh¬accoutlogsuperpeak}\\
   \Xbeefy &= \token{\$jam\_beefy}
 \end{align}


### PR DESCRIPTION
### current main
<img width="611" height="57" alt="image" src="https://github.com/user-attachments/assets/0a00f8ab-f80f-41f0-9601-c1dbc5dc83fd" />

<img width="492" height="53" alt="image" src="https://github.com/user-attachments/assets/e0b56556-af18-4c91-a125-498b7804f105" />


### after fix
<img width="748" height="61" alt="image" src="https://github.com/user-attachments/assets/5958f9c3-3bf2-4412-873e-ae802c7840e3" />

<img width="611" height="66" alt="image" src="https://github.com/user-attachments/assets/5c72d6b2-e55e-46cb-8345-2767f711b112" />

In equations (17.17) and (18.1), the validator index `v` was previously
encoded implicitly in the subscript of the signing operator `\fnsigndata`. Under the
current LaTeX setup, this caused the index to be dropped or rendered
ambiguously.

Note: the `\bar{}` and `BLS` notation shift due to the definitions in `preamble.tex` [line350](https://github.com/gavofyork/graypaper/blob/d3512eddbb55bc294fad43591808848c256215cb/preamble.tex#L350) and [line194](https://github.com/gavofyork/graypaper/blob/d3512eddbb55bc294fad43591808848c256215cb/preamble.tex#L194)
