### PR TITLE
Restrict bless to manager service

### DIFF
--- a/text/pvm_invocations.tex
+++ b/text/pvm_invocations.tex
@@ -742,6 +742,7 @@ Other than the gas-counter which is explicitly defined, elements of \textsc{pvm}
     \end{cases} \\
     \tup{\execst', \registers'_7, (\imX'_\im¬state)_{\tup{\ps¬manager, \ps¬assigners, \ps¬delegator, \ps¬registrar, \ps¬alwaysaccers}}} &= \begin{cases}
       \tup{\panic, \registers_7, (\imX_\im¬state)_{\tup{\ps¬manager, \ps¬assigners, \ps¬delegator, \ps¬registrar, \ps¬alwaysaccers}}} &\when \set{\mathbf{z}, \mathbf{a}} \ni \error \\
+      \tup{\continue, \mathtt{HUH}, (\imX_\im¬state)_{\tup{\ps¬manager, \ps¬assigners, \ps¬delegator, \ps¬registrar, \ps¬alwaysaccers}}} &\otherwhen \imX_\im¬id \ne (\imX_\im¬state)_\ps¬manager \\
       \tup{\continue, \mathtt{WHO}, (\imX_\im¬state)_{\tup{\ps¬manager, \ps¬assigners, \ps¬delegator, \ps¬registrar, \ps¬alwaysaccers}}} &\otherwhen \tup{m, v, r} \not\in \serviceid^3 \\
       \tup{\continue, \mathtt{OK}, \tuple{m, \mathbf{a}, v, r, \mathbf{z}}} &\otherwise \\
     \end{cases}


### PR DESCRIPTION
Without this check, any service can call `bless` during accumulation to grant itself arbitrary governance roles in working state: manager, registrar, assigners, delegator. 

These writes are discarded by the accumulation resolution (which only honors the real manager's post-state for governance fields), but the side effects of subsequent privileged calls persist.

Concrete exploit paths:
- Call `bless` to become manager, then `new` with non-zero gratis for free storage.
- Call `bless` to become registrar, then `new` with a low service ID.

The fix adds a `HUH` guard in `bless` , returning early if the caller is not the current manager. This matches the existing pattern for `assign` and `designate` calls.

Fixes #512

cc @boymaas
