### PR TITLE
Constrain preimage length parameter to bloblength (< 2^32) in preimage-related host calls

### DIFF
--- a/text/pvm_invocations.tex
+++ b/text/pvm_invocations.tex
@@ -922,7 +922,7 @@ Other than the gas-counter which is explicitly defined, elements of \textsc{pvm}
     \end{cases} \\
     \tup{\execst', \registers'_7, \registers'_8} &\equiv \begin{cases}
       \tup{\continue, \mathtt{HUH}, \registers_8} &\when z \not\in \bloblength \\
-      \tup{\panic, \registers_7, \registers_8} &\when h = \error \\
+      \tup{\panic, \registers_7, \registers_8} &\otherwhen h = \error \\
       \tup{\continue, \mathtt{NONE}, 0} &\otherwhen \mathbf{a} = \error \\
       \tup{\continue, 0, 0} &\otherwhen \mathbf{a} = \sq{} \\
       \tup{\continue, 1 + 2^{32}x, 0} &\otherwhen \mathbf{a} = \sq{x} \\
@@ -949,7 +949,7 @@ Other than the gas-counter which is explicitly defined, elements of \textsc{pvm}
     \end{cases} \\
     \tup{\execst', \registers'_7, \imX'_\im¬self} &\equiv \begin{cases}
       \tup{\continue, \mathtt{HUH}, \imX_\im¬self} &\when z \not \in \bloblength \\
-      \tup{\panic, \registers_7, \imX_\im¬self} &\when h = \error \\
+      \tup{\panic, \registers_7, \imX_\im¬self} &\otherwhen h = \error \\
       \tup{\continue, \mathtt{HUH}, \imX_\im¬self} &\otherwhen \mathbf{a} = \error \\
       \tup{\continue, \mathtt{FULL}, \imX_\im¬self} &\otherwhen \mathbf{a}_\sa¬balance < \mathbf{a}_\sa¬minbalance \\
       \tup{\continue, \mathtt{OK}, \mathbf{a}} &\otherwise \\
@@ -980,7 +980,7 @@ Other than the gas-counter which is explicitly defined, elements of \textsc{pvm}
     \end{cases} \\
     \tup{\execst', \registers'_7, \imX'_\im¬self} &\equiv \begin{cases}
       \tup{\continue, \mathtt{HUH}, \imX_\im¬self} &\when z \not \in \bloblength \\
-      \tup{\panic, \registers_7, \imX_\im¬self} &\when h = \error \\
+      \tup{\panic, \registers_7, \imX_\im¬self} &\otherwhen h = \error \\
       \tup{\continue, \mathtt{HUH}, \imX_\im¬self} &\otherwhen \mathbf{a} = \error \\
       \tup{\continue, \mathtt{OK}, \mathbf{a}} &\otherwise \\
     \end{cases} \\
@@ -1023,7 +1023,7 @@ Other than the gas-counter which is explicitly defined, elements of \textsc{pvm}
     \end{cases} \\
     \tup{\execst', \registers'_7, \imX'_\im¬provisions} &\equiv \begin{cases}
       \tup{\continue, \mathtt{HUH}, \imX_\im¬provisions} &\when z \not \in \bloblength \\
-      \tup{\panic, \registers_7, \imX_\im¬provisions} &\when \mathbf{i} = \error \\
+      \tup{\panic, \registers_7, \imX_\im¬provisions} &\otherwhen \mathbf{i} = \error \\
       \tup{\continue, \mathtt{WHO}, \imX_\im¬provisions} &\otherwhen \mathbf{a} = \none \\
       \tup{\continue, \mathtt{HUH}, \imX_\im¬provisions} &\otherwhen \mathbf{a}_\sa¬requests[\tup{\blake{\mathbf{i}}, z}] \ne \sq{} \\
       \tup{\continue, \mathtt{HUH}, \imX_\im¬provisions} &\otherwhen \tup{s, \mathbf{i}} \in \imX_\im¬provisions \\

--- a/text/pvm_invocations.tex
+++ b/text/pvm_invocations.tex
@@ -921,6 +921,7 @@ Other than the gas-counter which is explicitly defined, elements of \textsc{pvm}
       \error &\otherwise\\
     \end{cases} \\
     \tup{\execst', \registers'_7, \registers'_8} &\equiv \begin{cases}
+      \tup{\continue, \mathtt{HUH}, \registers_8} &\when z \not\in \bloblength \\
       \tup{\panic, \registers_7, \registers_8} &\when h = \error \\
       \tup{\continue, \mathtt{NONE}, 0} &\otherwhen \mathbf{a} = \error \\
       \tup{\continue, 0, 0} &\otherwhen \mathbf{a} = \sq{} \\
@@ -947,6 +948,7 @@ Other than the gas-counter which is explicitly defined, elements of \textsc{pvm}
       \error &\otherwise\\
     \end{cases} \\
     \tup{\execst', \registers'_7, \imX'_\im¬self} &\equiv \begin{cases}
+      \tup{\continue, \mathtt{HUH}, \imX_\im¬self} &\when z \not \in \bloblength \\
       \tup{\panic, \registers_7, \imX_\im¬self} &\when h = \error \\
       \tup{\continue, \mathtt{HUH}, \imX_\im¬self} &\otherwhen \mathbf{a} = \error \\
       \tup{\continue, \mathtt{FULL}, \imX_\im¬self} &\otherwhen \mathbf{a}_\sa¬balance < \mathbf{a}_\sa¬minbalance \\
@@ -977,6 +979,7 @@ Other than the gas-counter which is explicitly defined, elements of \textsc{pvm}
       \error &\otherwise\\
     \end{cases} \\
     \tup{\execst', \registers'_7, \imX'_\im¬self} &\equiv \begin{cases}
+      \tup{\continue, \mathtt{HUH}, \imX_\im¬self} &\when z \not \in \bloblength \\
       \tup{\panic, \registers_7, \imX_\im¬self} &\when h = \error \\
       \tup{\continue, \mathtt{HUH}, \imX_\im¬self} &\otherwhen \mathbf{a} = \error \\
       \tup{\continue, \mathtt{OK}, \mathbf{a}} &\otherwise \\
@@ -1019,6 +1022,7 @@ Other than the gas-counter which is explicitly defined, elements of \textsc{pvm}
       \none &\otherwise
     \end{cases} \\
     \tup{\execst', \registers'_7, \imX'_\im¬provisions} &\equiv \begin{cases}
+      \tup{\continue, \mathtt{HUH}, \imX_\im¬provisions} &\when z \not \in \bloblength \\
       \tup{\panic, \registers_7, \imX_\im¬provisions} &\when \mathbf{i} = \error \\
       \tup{\continue, \mathtt{WHO}, \imX_\im¬provisions} &\otherwhen \mathbf{a} = \none \\
       \tup{\continue, \mathtt{HUH}, \imX_\im¬provisions} &\otherwhen \mathbf{a}_\sa¬requests[\tup{\blake{\mathbf{i}}, z}] \ne \sq{} \\


### PR DESCRIPTION
### Background

The four preimage-related host calls (```solicit```, ```forget```, ```query```, ```provide```) accept the preimage length as z ∈ pvmreg = N_{2^{64}}. However, the preimage lookup dictionary ((9.3) in GP 0.7.2) stores the size as bloblength = N_L = N_{2^{32}}. The host call definitions are therefore inconsistent with the account type they operate on.

This inconsistency propagates into the storage footprint and threshold balance formulae ((9.8) in GP 0.7.2).
 A single request entry with z = 2^{64} - 1 contributes 81 + z = 2^{64} + 80 to the sum — a value that cannot be represented in the declared type N_{2^{64}}. Even for values of z where the storage footprint fits in 64 bits, the subsequent threshold balance computation multiplying it with B_L (currently 1 but can be increased in the future) could exceed N_{2^{64}}, requiring 128-bit intermediate arithmetic or overflow detection that may not be available in all implementation languages.

For provide specifically, z is also used to read memory. When z >= 2^{32} the memory read would exceed the 32-bit PVM address space and produce a panic exit — the wrong result code for an invalid argument. An explicit check is therefore needed to return HUH rather than panic.

### Proposal

All four calls return HUH if z >= 2^{32}, checked before any memory access or state lookup.

### Benefits

1. Fixes the type inconsistency: with z < 2^{32}, the octets sum stays within N_{2^{64}} for a realistic number of entries, making the declared type correct.
2. Corrects the error code for provide: large z currently produces panic; the explicit check returns the more appropriate HUH.
3. Reduces cross-implementation divergence: an explicit bound removes a source of inconsistency between implementations that may handle the large-z case differently.
4. Aligns with the existing definitions: the preimage lookup dictionary key is already defined as (hash, bloblength) — the host calls should enforce the same constraint.