### PR TITLE
Limit the number of parallel inner VMs in refine

### DIFF
--- a/preamble.tex
+++ b/preamble.tex
@@ -822,7 +822,14 @@
   \right.
 }
 
-\newcommand*{\jamdraftversion}{\input{VERSION}\!\!\!\!}
+% Using \include inside of a \title is broken in newer versions of TeX live for some reason;
+% fortunately we can just manually read the file as a workaround.
+\newread\versionfile
+  \openin\versionfile=VERSION
+  \read\versionfile to\jamdraftversionraw
+\closein\versionfile
+
+\newcommand*{\jamdraftversion}{\jamdraftversionraw\!\!\!\!}
 \newcommand*{\jamdraftversionstring}{\jamdraftversion}
 
 \newcommand*{\makegpbackground}{

--- a/text/pvm_invocations.tex
+++ b/text/pvm_invocations.tex
@@ -594,7 +594,7 @@ These assume some refine context pair $\tup{\mathbf{m}, \mathbf{e}} \in \tuple{\
     \using n &= \min(n \in \N : n \not\in \keys{\mathbf{m}}) \\
     \using \mathbf{u} &= \tup{\is{\ram¬value}{[0, 0, \dots]},\is{\ram¬access}{[\none, \none, \dots]}} \\
     \tup{\execst', \registers'_7, \mathbf{m}} &\equiv \begin{cases}
-      \tup{\continue, \mathtt{FULL}, \mathbf{m}} &\when \len{\mathbf{m}} \ge 4 \\
+      \tup{\continue, \mathtt{FULL}, \mathbf{m}} &\when \len{\mathbf{m}} \ge 63 \\
       \tup{\panic, \registers_7, \mathbf{m}} &\otherwhen \mathbf{p} = \error \\
       \tup{\continue, \mathtt{HUH}, \mathbf{m}} &\otherwhen \deblob(\mathbf{p}, i) = \error \\
       \tup{\continue, n, \mathbf{m} \cup \set{\kv{n}{\tup{\mathbf{p}, \mathbf{u}, i, \bot}}} } &\otherwise \\

--- a/text/pvm_invocations.tex
+++ b/text/pvm_invocations.tex
@@ -594,7 +594,8 @@ These assume some refine context pair $\tup{\mathbf{m}, \mathbf{e}} \in \tuple{\
     \using n &= \min(n \in \N : n \not\in \keys{\mathbf{m}}) \\
     \using \mathbf{u} &= \tup{\is{\ram¬value}{[0, 0, \dots]},\is{\ram¬access}{[\none, \none, \dots]}} \\
     \tup{\execst', \registers'_7, \mathbf{m}} &\equiv \begin{cases}
-      \tup{\panic, \registers_7, \mathbf{m}} &\when \mathbf{p} = \error \\
+      \tup{\continue, \mathtt{FULL}, \mathbf{m}} &\when \len{\mathbf{m}} \ge 4 \\
+      \tup{\panic, \registers_7, \mathbf{m}} &\otherwhen \mathbf{p} = \error \\
       \tup{\continue, \mathtt{HUH}, \mathbf{m}} &\otherwhen \deblob(\mathbf{p}, i) = \error \\
       \tup{\continue, n, \mathbf{m} \cup \set{\kv{n}{\tup{\mathbf{p}, \mathbf{u}, i, \bot}}} } &\otherwise \\
     \end{cases} \\


### PR DESCRIPTION
This PR limits the maximum number of parallel inner VMs that can be instantiated in refine.

This allows us to have a guaranteed cap on the maximum memory usage a refine invocation can have, and it also allows the PVM implementations to appropriately preallocate resources (for example, preallocate enough address space for the host VM and all of the potential inner VMs, etc.).

~~The exact numer (4) was mostly arbitrary picked and is subject to change if the need arises.~~ Changed the limit to 63.

Side note: considering we're targeting ~12 refine invocations in parallel this might not be enough to limit the maximum memory usage to a reasonable value (especially with the current RAM prices) *if* allocating memory ends up being cheap enough (we should have a better idea on how costly it will be once I'll finally make the memory paging gas metered), so we might still need to introduce a more granular memory limit; nevertheless limiting the number of VMs that can be spawned should still be useful.
