### PR TITLE
Propose change of extrinsic hash definition to allow checking for individual extrinsic preimages.

### DIFF
--- a/text/header.tex
+++ b/text/header.tex
@@ -28,11 +28,16 @@ The extrinsic hash is a Merkle commitment to the block's extrinsic data, taking 
   \H_\¬extrinsichash \equiv \blake{\encode{\blakemany{\mathbf{a}}}} \\
   \where \mathbf{a} &= \sq{
     \encodetickets{\xttickets},
-    \encodepreimages{\xtpreimages},
+    \mathbf{p},
     \mathbf{g},
     \encodeassurances{\xtassurances},
     \encodedisputes{\xtdisputes}
   } \\
+  \also \mathbf{p} &= \encode{\var{\sq{\build{
+    \tup{\encode[4]{\xp¬serviceindex}, \blake{\xg¬data}}
+  }{
+    \tup{\xg¬serviceindex, \xg¬data} \orderedin \xtpreimages
+  }}}}
   \also \mathbf{g} &= \encode{\var{\sq{\build{
     \tup{\blake{\xg¬workreport}, \encode[4]{\xg¬timeslot}, \var{\xg¬credential}}
   }{

--- a/text/header.tex
+++ b/text/header.tex
@@ -34,9 +34,9 @@ The extrinsic hash is a Merkle commitment to the block's extrinsic data, taking 
     \encodedisputes{\xtdisputes}
   } \\
   \also \mathbf{p} &= \encode{\var{\sq{\build{
-    \tup{\encode[4]{\xp¬serviceindex}, \blake{\xg¬data}}
+    \tup{\encode[4]{\xp¬serviceindex}, \blake{\xp¬data}}
   }{
-    \tup{\xg¬serviceindex, \xg¬data} \orderedin \xtpreimages
+    \tup{\xp¬serviceindex, \xp¬data} \orderedin \xtpreimages
   }}}}
   \also \mathbf{g} &= \encode{\var{\sq{\build{
     \tup{\blake{\xg¬workreport}, \encode[4]{\xg¬timeslot}, \var{\xg¬credential}}

--- a/text/header.tex
+++ b/text/header.tex
@@ -37,7 +37,7 @@ The extrinsic hash is a Merkle commitment to the block's extrinsic data, taking 
     \tup{\encode[4]{\xp¬serviceindex}, \blake{\xp¬data}}
   }{
     \tup{\xp¬serviceindex, \xp¬data} \orderedin \xtpreimages
-  }}}}
+  }}}} \\
   \also \mathbf{g} &= \encode{\var{\sq{\build{
     \tup{\blake{\xg¬workreport}, \encode[4]{\xg¬timeslot}, \var{\xg¬credential}}
   }{

--- a/text/header.tex
+++ b/text/header.tex
@@ -22,7 +22,7 @@ $\fngetparent$ is thus defined as being the mapping from one block header to its
 
 We only require implementations to store headers of ancestors which were authored in the previous $\Cmaxlookupanchorage = 24$ hours of any block $\block$ they wish to validate.
 
-The extrinsic hash is a Merkle commitment to the block's extrinsic data, taking care to allow for the possibility of reports to individually have their inclusion proven. Given any block $\block = \tup{\header, \extrinsic}$, then formally:
+The extrinsic hash is a Merkle commitment to the block's extrinsic data, taking care to allow for the possibility of reports and preimages to individually have their inclusion proven. Given any block $\block = \tup{\header, \extrinsic}$, then formally:
 \begin{align}
   \H_\¬extrinsichash &\in \hash \ ,\quad
   \H_\¬extrinsichash \equiv \blake{\encode{\blakemany{\mathbf{a}}}} \\


### PR DESCRIPTION
This PR modify the way extrinsic preimages are hashed to allow verifying a single preimage without having to download all preimages. (it simply replace preimage data by its blake hash).

cc\ @zdave-parity 