### PR TITLE
Expose lookup anchor posterior root and anchor slot in refinement context

### DIFF
--- a/preamble.tex
+++ b/preamble.tex
@@ -504,8 +504,10 @@
 \newcommand*{\wc¬anchorhash}{a}
 \newcommand*{\wc¬anchorpoststate}{s}
 \newcommand*{\wc¬anchoraccoutlog}{b}
+\newcommand*{\wc¬anchortime}{n}
 \newcommand*{\wc¬lookupanchorhash}{l}
 \newcommand*{\wc¬lookupanchortime}{t}
+\newcommand*{\wc¬lookupanchorpoststate}{r}
 \newcommand*{\wc¬prerequisites}{\mathbf{p}}
 
 \newcommand*{\serviceaccount}{\mathbb{A}}
@@ -597,6 +599,7 @@
 \newcommand*{\rh¬headerhash}{h}
 \newcommand*{\rh¬accoutlogsuperpeak}{b}
 \newcommand*{\rh¬stateroot}{s}
+\newcommand*{\rh¬timeslot}{t}
 \newcommand*{\rh¬reportedpackagehashes}{\mathbf{p}}
 
 

--- a/text/merklization.tex
+++ b/text/merklization.tex
@@ -23,9 +23,9 @@ The state serialization is then defined as the dictionary built from the amalgam
     &&C(2) &\mapsto \encode{\authqueue} \;, \\
     &&C(3) &\mapsto \encode{
       \var{\sq{\build{
-        \tup{\rh¬headerhash, \rh¬accoutlogsuperpeak, \rh¬stateroot, \var{\rh¬reportedpackagehashes}}
+        \tup{\rh¬headerhash, \rh¬accoutlogsuperpeak, \rh¬stateroot, \encode[4]{\rh¬timeslot}, \var{\rh¬reportedpackagehashes}}
       }{
-        \tup{\rh¬headerhash, \rh¬accoutlogsuperpeak, \rh¬stateroot, \rh¬reportedpackagehashes} \orderedin \recenthistory
+        \tup{\rh¬headerhash, \rh¬accoutlogsuperpeak, \rh¬stateroot, \rh¬timeslot, \rh¬reportedpackagehashes} \orderedin \recenthistory
       }}},
       \mmrencode{\accoutbelt}
     } \;, \\

--- a/text/recent_history.tex
+++ b/text/recent_history.tex
@@ -9,6 +9,7 @@ We retain in state information on the most recent $\Crecenthistorylen$ blocks. T
     \isa{\rh¬headerhash}{\hash},
     \isa{\rh¬stateroot}{\hash},
     \isa{\rh¬accoutlogsuperpeak}{\hash},
+    \isa{\rh¬timeslot}{\timeslot},
     \isa{\rh¬reportedpackagehashes}{\dictionary{\hash}{\hash}}
   }}\\
   \label{eq:accoutbeltspec}
@@ -39,7 +40,8 @@ The final state transition for $\recenthistory$ appends a new item including the
       \rh¬reportedpackagehashes,
       \is{\rh¬headerhash}{\blake{\theheader}},
       \is{\rh¬stateroot}{\zerohash},
-      \is{\rh¬accoutlogsuperpeak}{\mmrsuperpeak{\accoutbelt'}}
+      \is{\rh¬accoutlogsuperpeak}{\mmrsuperpeak{\accoutbelt'}},
+      \is{\rh¬timeslot}{\H_\¬timeslot}
       }}}^\Crecenthistorylen \\
     \where \rh¬reportedpackagehashes &= \set{\build{
         \kv{

--- a/text/recent_history.tex
+++ b/text/recent_history.tex
@@ -37,11 +37,11 @@ The final state transition for $\recenthistory$ appends a new item including the
   \label{eq:recenthistorydef}
   \begin{aligned}
     \recenthistory' &\equiv {\overleftarrow{\recenthistorypostparentstaterootupdate \append \tup{
-      \rh¬reportedpackagehashes,
       \is{\rh¬headerhash}{\blake{\theheader}},
       \is{\rh¬stateroot}{\zerohash},
       \is{\rh¬accoutlogsuperpeak}{\mmrsuperpeak{\accoutbelt'}},
-      \is{\rh¬timeslot}{\H_\¬timeslot}
+      \is{\rh¬timeslot}{\H_\¬timeslot},
+      \rh¬reportedpackagehashes
       }}}^\Crecenthistorylen \\
     \where \rh¬reportedpackagehashes &= \set{\build{
         \kv{

--- a/text/reporting_assurance.tex
+++ b/text/reporting_assurance.tex
@@ -52,14 +52,14 @@ We limit the sum of the number of items in the segment-root lookup dictionary an
 
 \subsubsection{Refinement Context}
 
-A \emph{refinement context}, denoted by the set $\workcontext$, describes the context of the chain at the point that the report's corresponding work-package was evaluated. It identifies two historical blocks, the \emph{anchor}, header hash $\wc¬anchorhash$ along with its associated posterior state-root $\wc¬anchorpoststate$ and accumulation output log super-peak $\wc¬anchoraccoutlog$; and the \emph{lookup-anchor}, header hash $\wc¬lookupanchorhash$ and timeslot $\wc¬lookupanchortime$. Finally, it identifies the hash of any prerequisite work-packages $\wc¬prerequisites$. Formally:
+A \emph{refinement context}, denoted by the set $\workcontext$, describes the context of the chain at the point that the report's corresponding work-package was evaluated. It identifies two historical blocks, the \emph{anchor}, header hash $\wc¬anchorhash$, timeslot $\wc¬anchortime$, posterior state-root $\wc¬anchorpoststate$ and accumulation output log super-peak $\wc¬anchoraccoutlog$; and the \emph{lookup-anchor}, header hash $\wc¬lookupanchorhash$, timeslot $\wc¬lookupanchortime$ and posterior state-root $\wc¬lookupanchorpoststate$. Finally, it identifies the hash of any prerequisite work-packages $\wc¬prerequisites$. Formally:
 \begin{equation}
   \label{eq:workcontext}
   \workcontext \equiv \tuple{\,\begin{alignedat}{5}
     \isa{\wc¬anchorhash&}{\hash}\,,\;
+    \isa{&\wc¬anchortime&}{\timeslot}\,,\;
     \isa{&\wc¬anchorpoststate&}{\hash}\,,\;
-    \isa{&\wc¬anchoraccoutlog&}{\hash}\,,\;
-    \isa{&\wc¬anchortime&}{\timeslot}\,,\;\\
+    \isa{&\wc¬anchoraccoutlog&}{\hash}\,,\;\\
     \isa{\wc¬lookupanchorhash&}{\hash}\,,\;
     \isa{&\wc¬lookupanchortime&}{\timeslot}\,,\;
     \isa{&\wc¬lookupanchorpoststate&}{\hash}\,,\;
@@ -361,10 +361,14 @@ We require that each lookup-anchor block be within the last $\Cmaxlookupanchorag
 \end{align}
 
 We also require that we have a record of it; this is one of the few conditions which cannot be checked purely with on-chain state and must be checked by virtue of retaining the series of the last $\Cmaxlookupanchorage$ headers as the ancestor set $\ancestors$. Since it is determined through the header chain, it is still deterministic and calculable. Formally:
-\begin{align}
-  \forall x \in \local¬incomingcontexts :\ \exists h, h' \in \ancestors:\ &h_\¬timeslot = x_\wc¬lookupanchortime \wedge \blake{h} = x_\wc¬lookupanchorhash \notag \\
-  &\wedge h'_\¬parent = \blake{h} \wedge h'_\¬priorstateroot = x_\wc¬lookupanchorpoststate
-\end{align}
+\begin{equation}
+  \forall x \in \local¬incomingcontexts : \exists h, h' \in \ancestors : \bigwedge \abracegroup{
+    h_\¬timeslot &= x_\wc¬lookupanchortime \\
+    \blake{h} &= x_\wc¬lookupanchorhash \\
+    h'_\¬parent &= \blake{h} \\
+    h'_\¬priorstateroot &= x_\wc¬lookupanchorpoststate
+  }
+\end{equation}
 
 We require that the work-package of the report not be the work-package of some other report made in the past. We ensure that the work-package not appear anywhere within our pipeline. Formally:
 \begin{align}

--- a/text/reporting_assurance.tex
+++ b/text/reporting_assurance.tex
@@ -58,9 +58,11 @@ A \emph{refinement context}, denoted by the set $\workcontext$, describes the co
   \workcontext \equiv \tuple{\,\begin{alignedat}{5}
     \isa{\wc¬anchorhash&}{\hash}\,,\;
     \isa{&\wc¬anchorpoststate&}{\hash}\,,\;
-    \isa{&\wc¬anchoraccoutlog&}{\hash}\,,\;\\
+    \isa{&\wc¬anchoraccoutlog&}{\hash}\,,\;
+    \isa{&\wc¬anchortime&}{\timeslot}\,,\;\\
     \isa{\wc¬lookupanchorhash&}{\hash}\,,\;
     \isa{&\wc¬lookupanchortime&}{\timeslot}\,,\;
+    \isa{&\wc¬lookupanchorpoststate&}{\hash}\,,\;
     \isa{&\wc¬prerequisites&}{\protoset{\hash}}
   \end{alignedat}}
 \end{equation}
@@ -349,7 +351,7 @@ There must be no duplicate work-package hashes (\ie two work-reports of the same
 
 We require that the anchor block be within the last $\Crecenthistorylen$ blocks and that its details be correct by ensuring that it appears within our most recent blocks $\recenthistorypostparentstaterootupdate$:
 \begin{align}
-  \forall x \in \local¬incomingcontexts : \exists y \in \recenthistorypostparentstaterootupdate : x_\wc¬anchorhash = y_\rh¬headerhash \wedge x_\wc¬anchorpoststate = y_\rh¬stateroot \wedge x_\wc¬anchoraccoutlog = y_\rh¬accoutlogsuperpeak \!\!\!\!\!\!
+  \forall x \in \local¬incomingcontexts : \exists y \in \recenthistorypostparentstaterootupdate : x_\wc¬anchorhash = y_\rh¬headerhash \wedge x_\wc¬anchorpoststate = y_\rh¬stateroot \wedge x_\wc¬anchoraccoutlog = y_\rh¬accoutlogsuperpeak \wedge x_\wc¬anchortime = y_\rh¬timeslot \!\!\!\!\!\!
 \end{align}
 
 We require that each lookup-anchor block be within the last $\Cmaxlookupanchorage$ timeslots:
@@ -360,7 +362,8 @@ We require that each lookup-anchor block be within the last $\Cmaxlookupanchorag
 
 We also require that we have a record of it; this is one of the few conditions which cannot be checked purely with on-chain state and must be checked by virtue of retaining the series of the last $\Cmaxlookupanchorage$ headers as the ancestor set $\ancestors$. Since it is determined through the header chain, it is still deterministic and calculable. Formally:
 \begin{align}
-  \forall x \in \local¬incomingcontexts :\ \exists h \in \ancestors: h_\¬timeslot = x_\wc¬lookupanchortime \wedge \blake{h} = x_\wc¬lookupanchorhash
+  \forall x \in \local¬incomingcontexts :\ \exists h, h' \in \ancestors:\ &h_\¬timeslot = x_\wc¬lookupanchortime \wedge \blake{h} = x_\wc¬lookupanchorhash \notag \\
+  &\wedge h'_\¬parent = \blake{h} \wedge h'_\¬priorstateroot = x_\wc¬lookupanchorpoststate
 \end{align}
 
 We require that the work-package of the report not be the work-package of some other report made in the past. We ensure that the work-package not appear anywhere within our pipeline. Formally:

--- a/text/serialization.tex
+++ b/text/serialization.tex
@@ -209,8 +209,10 @@ A block $\block$ is serialized as a tuple of its elements in regular order, as i
     \wcX_\wc¬anchorhash,
     \wcX_\wc¬anchorpoststate,
     \wcX_\wc¬anchoraccoutlog,
+    \encode[4]{\wcX_\wc¬anchortime},
     \wcX_\wc¬lookupanchorhash,
     \encode[4]{\wcX_\wc¬lookupanchortime},
+    \wcX_\wc¬lookupanchorpoststate,
     \var{\wcX_\wc¬prerequisites}
   }
   \\

--- a/text/serialization.tex
+++ b/text/serialization.tex
@@ -207,9 +207,9 @@ A block $\block$ is serialized as a tuple of its elements in regular order, as i
   \\
   \encode{\wcX \in \workcontext} &\equiv \encode{
     \wcX_\wc¬anchorhash,
+    \encode[4]{\wcX_\wc¬anchortime},
     \wcX_\wc¬anchorpoststate,
     \wcX_\wc¬anchoraccoutlog,
-    \encode[4]{\wcX_\wc¬anchortime},
     \wcX_\wc¬lookupanchorhash,
     \encode[4]{\wcX_\wc¬lookupanchortime},
     \wcX_\wc¬lookupanchorpoststate,


### PR DESCRIPTION
So, both are accessible by is-authorized and refine itself.