### PR TITLE
Auditing: Widen tranche-escalation comparand to 16 bits

### DIFF
--- a/text/auditing.tex
+++ b/text/auditing.tex
@@ -103,7 +103,7 @@ We can thus define $\local¬tranche\sub{n}$ beyond the initial tranche through a
   \nonumber\forall n > 0:&\\
   \label{eq:latertranches}
   \ \local¬seed\sub{n}(\wrX) &\in \bssignature{\activeset\subb{v}_\vk¬bs}{\Xaudit \concat \banderout{\H_\¬vrfsig}\concat\blake{\wrX}\append n}{\sq{}} \\
-  \ a_n(\wrX) &\equiv \textstyle\frac{\len{\activeset}}{256\Cauditbiasfactor}\banderout{\local¬seed\sub{n}(\wrX)}\sub{0} < \len{A_{n - 1}(\wrX) \setminus J_\top(\wrX)} \\
+  \ a_n(\wrX) &\equiv \textstyle\frac{\len{\activeset}}{65536\Cauditbiasfactor}\decode[2]{\banderout{\local¬seed\sub{n}(\wrX)}\subrange{0}{2}} < \len{A_{n - 1}(\wrX) \setminus J_\top(\wrX)} \\
   \ \local¬tranche\sub{n} &\equiv \set{\build{\wrX}{\wrX \in \local¬reports, \wrX \ne \none, a_n(\wrX)}}
 \end{align}
 


### PR DESCRIPTION
**Issue**: The later-tranche audit rule (auditing.tex, eq. latertranches) compares a single byte of VRF output against the no-show count. The bias factor defined right under it is F = 2 — "the expected number of validators … required to issue a judgment … given a single no-show." A single byte can't actually deliver 2: at one no-show only the byte value 0 passes the test, so the mean number summoned is 1023/256 ≈ 3.996, about double. It's not a rounding thing either — with one byte every reachable mean is a multiple of 1023/256 ≈ 3.996, and 2 isn't on that grid.

**Fix**: decode bytes 0–1 of the same VRF output as a little-endian u16.

Explanation:
[correction.pdf](https://github.com/user-attachments/files/28926020/correction.pdf)

POC — exact, by enumeration:

```python
from fractions import Fraction
V, F = 1023, 2
def expected_summons(bits, m):
    space = 2 ** bits
    q = sum(1 for r in range(space) if Fraction(V * r, space * F) < m)
    return V * Fraction(q, space)
assert expected_summons(8, 1)  == Fraction(1023, 256)       # 3.996
assert expected_summons(16, 1) == Fraction(131967, 65536)   # 2.014
```

