### PR TITLE
Fix typo in Accumulate Invocation result conversion

### DIFF
--- a/text/pvm_invocations.tex
+++ b/text/pvm_invocations.tex
@@ -231,7 +231,7 @@ We define $\Psi_A$, the Accumulation invocation function as:
         \is{\ao¬defxfers}{\imX_\im¬xfers},
         \is{\ao¬yield}{\mathbf{o}},
         \ao¬gasused,
-        \is{\ao¬provisions}{\imXY_\im¬provisions}
+        \is{\ao¬provisions}{\imX_\im¬provisions}
       } & \otherwhen \mathbf{o} \in \hash \\
       \tup{
         \is{\ao¬poststate}{\imX_\im¬state},


### PR DESCRIPTION
Fix branch result in the Accumulate Invocation collapse function.

https://graypaper.fluffylabs.dev/#/07f041d/383003383003?v=0.8.0

This appears to be a typo:

1. $(\mathbf{x}, \mathbf{y})_{\mathbf{p}}$ does not match the tuple-subscript convention.
2. According to the accumulation invocation semantics, this branch should output $\mathbf{x}_{\mathbf{p}}$.