### PR TITLE
Work-report: align tuple & prose field order with §C serialization

### DIFF
--- a/text/reporting_assurance.tex
+++ b/text/reporting_assurance.tex
@@ -29,7 +29,7 @@ A work-report guarantee, of the set $\guarantee$, consists of a work-report toge
 
 \subsubsection{Work Report}
 \label{sec:workreport}
-A work-report, of the set $\workreport$, is defined as a tuple of the work-package specification, $\wr¬avspec$; the refinement context, $\wr¬context$; the core-index (\ie on which the work is done), $\wr¬core$; as well as the authorizer hash $\wr¬authorizer$ and trace $\wr¬authtrace$; a segment-root lookup dictionary $\wr¬srlookup$; the gas consumed during the Is-Authorized invocation, $\wr¬authgasused$; and finally the work-digests $\wr¬digests$ which comprise the results of the evaluation of each of the items in the package together with some associated data. Formally:
+A work-report, of the set $\workreport$, is defined as a tuple of the work-package specification, $\wr¬avspec$; the refinement context, $\wr¬context$; the core-index (\ie on which the work is done), $\wr¬core$; as well as the authorizer hash $\wr¬authorizer$; the gas consumed during the Is-Authorized invocation, $\wr¬authgasused$; the trace $\wr¬authtrace$; a segment-root lookup dictionary $\wr¬srlookup$; and finally the work-digests $\wr¬digests$ which comprise the results of the evaluation of each of the items in the package together with some associated data. Formally:
 \begin{equation}
   \label{eq:workreport}
   \workreport \equiv \tuple{
@@ -38,10 +38,10 @@ A work-report, of the set $\workreport$, is defined as a tuple of the work-packa
       \isa{\wr¬context}{\workcontext},\
       \isa{\wr¬core}{\coreindex},\
       \isa{\wr¬authorizer}{\hash},\
-      \isa{\wr¬authtrace}{\blob},\\
-      &\isa{\wr¬srlookup}{\dictionary{\hash}{\hash}},\
-      \isa{\wr¬digests}{\sequence[1:\Cmaxpackageitems]{\workdigest}},\
-      \isa{\wr¬authgasused}{\gas}
+      \isa{\wr¬authgasused}{\gas},\\
+      &\isa{\wr¬authtrace}{\blob},\
+      \isa{\wr¬srlookup}{\dictionary{\hash}{\hash}},\
+      \isa{\wr¬digests}{\sequence[1:\Cmaxpackageitems]{\workdigest}}
     \end{aligned}
   }
 \end{equation}

--- a/text/work_packages_and_reports.tex
+++ b/text/work_packages_and_reports.tex
@@ -193,7 +193,7 @@ We now come to the work-report computation function $\computereport$. This forms
       \error &\when E \\
       \tup{\begin{aligned}
         &\wr¬avspec, \is{\wr¬context}{\wpX_\wp¬context}, \¬core, \\
-        &\is{\wr¬authorizer}{\wpX_\wp¬authorizer}, \wr¬authtrace, \wr¬srlookup, \wr¬digests, \wr¬authgasused
+        &\is{\wr¬authorizer}{\wpX_\wp¬authorizer}, \wr¬authgasused, \wr¬authtrace, \wr¬srlookup, \wr¬digests
       \end{aligned}} &\otherwise
     \end{cases}
   }


### PR DESCRIPTION
 The work-report `\workreport` field order is stated inconsistently. The prose, `eq:workreport`, and `eq:computereport` all place the Is-Authorized gas `\wr¬authgasused` last (the prose puts it 7th), but the §C `\encode{R}` places it **5th**, right after `\wr¬authorizer`. The vectors and reference implementations follow §C.

  This aligns the three definition-side statements to §C (gas 5th); `\encode{R}` is unchanged. All
  other report-field references use subscript access, so nothing else is affected.