### PR TITLE
Fix upper boundary of the `grow_heap` hostcall

### DIFF
--- a/text/pvm_invocations.tex
+++ b/text/pvm_invocations.tex
@@ -324,7 +324,7 @@ With base cost $c$, total gas is $c + \fnmemgas(L, \ell)$. The host-call table b
     % Page index of the start of the RW data region.
     \using a &= \frac{2\Cpvminitzonesize + \rnq{\len{\mathbf{o}}}}{\Cpvmpagesize} \\
     % Page index plus one of the last possible RW data region page.
-    \using b &= \frac{2^{32} - 3\Cpvminitzonesize - \Cpvminitinputsize - \rnp{s}}{\Cpvmpagesize} \\
+    \using b &= \frac{2^{32} - 3\Cpvminitzonesize - \Cpvminitinputsize - \rnq{s}}{\Cpvmpagesize} \\
     % Current writable page count of the RW data region.
     \using c &= |\set{\build{p \in \Nclamp{a}{b}}{\memory_\ram¬access\subb{p} = \mathrm{W}}}| \\
     % Current heap pointer.


### PR DESCRIPTION
Address space in the standard program initialization scheme is distributed in 64k chunks. The maximum amount of address space that the RW data region can consume depends on the amount of stack space (heap grows up, stack grows down, they can meet in the middle divided by at least one 64k guard page). The current `grow_heap` rounds the stack size (`s`) to the nearest 4k (`rnp`), and that is correct for how much stack is actually accessible, but not for how much address space it reserves, and the address space is what determines how much RW data/heap is allowed to grow, so this should be rounded to the nearest 64k (`rnq`) instead.