### PR TITLE
Cite ZIP 215 for Ed25519 signature validation criteria

### DIFF
--- a/biblio.bib
+++ b/biblio.bib
@@ -343,3 +343,11 @@
     year = {2020},
     url = {https://z.cash/technology/jubjub/}
 }
+
+@misc{zip215,
+    author = {Henry de Valence},
+    title = {{Explicitly Defining and Modifying Ed25519 Validation Rules}},
+    howpublished = {ZIP 215},
+    year = {2020},
+    url = {https://zips.z.cash/zip-0215}
+}

--- a/text/notation.tex
+++ b/text/notation.tex
@@ -162,7 +162,7 @@ The inputs of a hash function should be expected to be passed through our serial
 
 \subsubsection{Signing Schemes}\label{sec:signing}
 
-$\edsignature{k}{m \in \blob} \subset \blob[64]$ is the set of valid Ed25519 signatures, defined by \cite{rfc8032}, made through knowledge of a secret key whose public key counterpart is $k \in \hash$ and whose message is $m$. To aid readability, we denote the set of valid public keys $\edkey$.
+$\edsignature{k}{m \in \blob} \subset \blob[64]$ is the set of valid Ed25519 signatures, defined by \cite{rfc8032}, made through knowledge of a secret key whose public key counterpart is $k \in \hash$ and whose message is $m$. To aid readability, we denote the set of valid public keys $\edkey$. Where \cite{rfc8032} admits alternative validation criteria, we adopt those of \cite{zip215}: the cofactored group equation must be satisfied and the uncofactored alternative must not be used; the signature scalar must be less than the prime order of the group; and the encodings of the public key and of the commitment point need not have reduced $y$-coordinates.
 
 We denote the set of valid Bandersnatch public keys as $\bskey$, defined in appendix \ref{sec:bandersnatch}. $\bssignature{k \in \bskey}{x \in \blob}{m \in \blob} \subset \blob[96]$ is the set of valid singly-contextualized \textsc{vrf} signatures utilizing the secret counterpart to the public key $k$, some context $x$ and message $m$.
 

--- a/text/notation.tex
+++ b/text/notation.tex
@@ -162,7 +162,7 @@ The inputs of a hash function should be expected to be passed through our serial
 
 \subsubsection{Signing Schemes}\label{sec:signing}
 
-$\edsignature{k}{m \in \blob} \subset \blob[64]$ is the set of valid Ed25519 signatures, defined by \cite{rfc8032}, made through knowledge of a secret key whose public key counterpart is $k \in \hash$ and whose message is $m$. To aid readability, we denote the set of valid public keys $\edkey$. Where \cite{rfc8032} admits alternative validation criteria, we adopt those of \cite{zip215}: the cofactored group equation must be satisfied and the uncofactored alternative must not be used; the signature scalar must be less than the prime order of the group; and the encodings of the public key and of the commitment point need not have reduced $y$-coordinates.
+$\edsignature{k}{m \in \blob} \subset \blob[64]$ is the set of valid Ed25519 signatures, defined by \cite{rfc8032}, made through knowledge of a secret key whose public key counterpart is $k \in \hash$ and whose message is $m$. To aid readability, we denote the set of valid public keys $\edkey$. Where \cite{rfc8032} admits alternative validation criteria, we adopt those of \cite{zip215}.
 
 We denote the set of valid Bandersnatch public keys as $\bskey$, defined in appendix \ref{sec:bandersnatch}. $\bssignature{k \in \bskey}{x \in \blob}{m \in \blob} \subset \blob[96]$ is the set of valid singly-contextualized \textsc{vrf} signatures utilizing the secret counterpart to the public key $k$, some context $x$ and message $m$.
 


### PR DESCRIPTION
`notation.tex` defines valid Ed25519 signatures by reference to RFC 8032 alone, but
RFC 8032 §5.1.7 explicitly permits two different verification equations:

> Check the group equation [8][S]B = [8]R + [8][k]A'. It's sufficient, but not
> required, to instead check [S]B = R + [k]A'.

So validity is not determined by the current text. Two conforming implementations can
disagree on whether a signature is valid, and for assurances, guarantees and judgments
that means disagreeing on whether a block is valid.

This came up implementing verification in `jam-forge`: with only RFC 8032 to work from,
both the verification equation and the treatment of non-canonical encodings have to be
chosen without guidance, and both are consensus-visible. The vectors in
`jam-conformance/crypto/ed25519` exist because the answers diverge in practice.