### PR TITLE
Fix forget host-call incorrectly dropping preimage

### DIFF
--- a/text/pvm_invocations.tex
+++ b/text/pvm_invocations.tex
@@ -957,12 +957,13 @@ These assume a context $\imXY \in \implications^2$; see equation \ref{eq:implica
     \end{cases} \\
     \using \mathbf{a} &= \begin{cases}
       \imX_\im¬self \text{ except:} &\\
+      \quad \keys{\mathbf{a}_\sa¬requests} = \keys{(\imX_\im¬self)_\sa¬requests} \setminus \set{\tup{h, z}} &\when (\imX_\im¬self)_\sa¬requests\subb{h, z} = \sq{} \\
       \quad \left.
         \begin{aligned}
           \keys{\mathbf{a}_\sa¬requests} &= \keys{(\imX_\im¬self)_\sa¬requests} \setminus \set{\tup{h, z}}\ ,\\[2pt]
           \keys{\mathbf{a}_\sa¬preimages} &= \keys{(\imX_\im¬self)_\sa¬preimages} \setminus \set{h}
         \end{aligned}
-      \ \right\} &\when (\imX_\im¬self)_\sa¬requests\subb{h, z} \in \set{\sq{}, \sq{x, y}},\ y < t - \Cexpungeperiod \\
+      \ \right\} &\when (\imX_\im¬self)_\sa¬requests\subb{h, z} = \sq{x, y},\ y < t - \Cexpungeperiod \\
       \quad \mathbf{a}_\sa¬requests\subb{h, z} = \sq{x, t} &\when (\imX_\im¬self)_\sa¬requests\subb{h, z} = \sq{x} \\
       \quad \mathbf{a}_\sa¬requests\subb{h, z} = \sq{w, t} &\when (\imX_\im¬self)_\sa¬requests\subb{h, z} = \sq{x, y, w},\ y < t - \Cexpungeperiod \\
       \error &\otherwise\\


### PR DESCRIPTION
As we can not know the length of a preimage prior to it being provided, we allow multiple requests with the same hash but differing lengths to be made. Only a request with the correct length can ever be satisfied and transition to a provided state. We must only drop the preimage when we drop a request which is in a provided state. A request in the requested state (empty status sequence) does _not_ imply that we do not have the preimage; its length may be incorrect and another request with the correct length may be in a provided state.