### PR TITLE
Auditing: escalate on negative judgment in eq. latertranches

### DIFF
--- a/text/auditing.tex
+++ b/text/auditing.tex
@@ -98,12 +98,15 @@ We further define $J_\top$ and $J_\bot$ to be the validator indices who we know 
 
 We are able to define $\local¬tranche\sub{n}$ for tranches beyond the first on the basis of the number of validators who we know are required to conduct an audit yet from whom we have not yet seen a judgment. It is possible that the late arrival of information alters $\local¬tranche\sub{n}$ and nodes should reevaluate and act accordingly should this happen.
 
-We can thus define $\local¬tranche\sub{n}$ beyond the initial tranche through a new \textsc{vrf} which acts upon the set of \emph{no-show} validators.
+We can thus define $\local¬tranche\sub{n}$ beyond the initial tranche: a work-report for which we have seen any negative judgment is always included, as stated above; otherwise its inclusion is determined through a new \textsc{vrf} which acts upon the set of \emph{no-show} validators.
 \begin{align}
   \nonumber\forall n > 0:&\\
   \label{eq:latertranches}
   \ \local¬seed\sub{n}(\wrX) &\in \bssignature{\activeset\subb{v}_\vk¬bs}{\Xaudit \concat \banderout{\H_\¬vrfsig}\concat\blake{\wrX}\append n}{\sq{}} \\
-  \ a_n(\wrX) &\equiv \textstyle\frac{\len{\activeset}}{65536\Cauditbiasfactor}\decode[2]{\banderout{\local¬seed\sub{n}(\wrX)}\subrange{0}{2}} < \len{A_{n - 1}(\wrX) \setminus J_\top(\wrX)} \\
+  \ a_n(\wrX) &\equiv \bigvee\abracegroup{
+    &J_\bot(\wrX) \neq \emptyset \\
+    &\textstyle\frac{\len{\activeset}}{65536\Cauditbiasfactor}\decode[2]{\banderout{\local¬seed\sub{n}(\wrX)}\subrange{0}{2}} < \len{A_{n - 1}(\wrX) \setminus J_\top(\wrX)}
+  } \\
   \ \local¬tranche\sub{n} &\equiv \set{\build{\wrX}{\wrX \in \local¬reports, \wrX \ne \none, a_n(\wrX)}}
 \end{align}
 


### PR DESCRIPTION
The auditing prose gives two reasons for a work-report to enter a later tranche. From §17.4 (Selection of Reports):

> New tranches may contain items from q stemming from one of two reasons: either a negative judgment has been received; or the number of judgments from the previous tranche is less than the number of announcements from said tranche. In the first case, the validator is always required to issue a judgment on the work-report. In the second case, a new special-purpose VRF must be constructed…

The Verdicts overview (§10) states the first case even more directly: "In the event of a negative judgment, then all validators audit said work-report."

However, the escalation predicate `a_n` in `eq. latertranches` formalizes only the second reason. It compares the VRF draw against the no-show count, and the set of validators known to have judged the report negatively — defined immediately above the equation as `J_⊥` — appears nowhere in it. A validator who returns a negative judgment therefore affects escalation only by being absent from the set of positive judgers, `J_⊤` — exactly as if it had not responded at all.

The practical difference is large. Under the equation as written, a negative judgment recruits roughly F = 2 extra auditors per 8-second tranche, the same drip as a single no-show. A verdict needs two-thirds-plus-one of the validator set (`eq. verdicts`) — 683 judgments at full size — so even with every recruit responding promptly, assembling one takes on the order of 340 tranches, i.e. ~45 minutes. Under the behaviour the prose mandates, all validators audit at once and the threshold is reachable in a single tranche. An implementation coding the equation literally gets the 45-minute version.

This PR adds the missing disjunct so the equation says what the prose already says: escalate when the set of negative judgments for the report is non-empty (`J_⊥(w) ≠ ∅`), or when the VRF draw selects us against the no-show count.