### PR TITLE
fix: forget deletes preimage blob without checking request length

### DIFF
--- a/text/pvm_invocations.tex
+++ b/text/pvm_invocations.tex
@@ -962,7 +962,8 @@ These assume a context $\imXY \in \implications^2$; see equation \ref{eq:implica
           \keys{\mathbf{a}_\sa¬requests} &= \keys{(\imX_\im¬self)_\sa¬requests} \setminus \set{\tup{h, z}}\ ,\\[2pt]
           \keys{\mathbf{a}_\sa¬preimages} &= \keys{(\imX_\im¬self)_\sa¬preimages} \setminus \set{h}
         \end{aligned}
-      \ \right\} &\when (\imX_\im¬self)_\sa¬requests\subb{h, z} \in \set{\sq{}, \sq{x, y}},\ y < t - \Cexpungeperiod \\
+      \ \right\} &\when (\imX_\im¬self)_\sa¬requests\subb{h, z} \in \set{\sq{}, \sq{x, y}},\ y < t - \Cexpungeperiod,\ z = \len{(\imX_\im¬self)_\sa¬preimages\subb{h}} \\
+      \quad \keys{\mathbf{a}_\sa¬requests} = \keys{(\imX_\im¬self)_\sa¬requests} \setminus \set{\tup{h, z}} &\otherwhen (\imX_\im¬self)_\sa¬requests\subb{h, z} \in \set{\sq{}, \sq{x, y}},\ y < t - \Cexpungeperiod \\
       \quad \mathbf{a}_\sa¬requests\subb{h, z} = \sq{x, t} &\when (\imX_\im¬self)_\sa¬requests\subb{h, z} = \sq{x} \\
       \quad \mathbf{a}_\sa¬requests\subb{h, z} = \sq{w, t} &\when (\imX_\im¬self)_\sa¬requests\subb{h, z} = \sq{x, y, w},\ y < t - \Cexpungeperiod \\
       \error &\otherwise\\


### PR DESCRIPTION
## The issue

Preimage blobs are keyed by hash alone; requests are keyed by `(hash, length)`. `forget` deletes `a_preimages[h]` whenever the request at `(h, z)` is forgettable, never checking that `z` is the blob's actual length.

Two facts make that a bypass of the expunge delay:

1. `solicit` only consults `requests`, so a service holding a blob can create a second request at any bogus length.
2. A never-supplied request (status `[]`) expunges with **zero** delay — the `y < t − C_expungeperiod` guard is vacuous without a `y`.

So two host calls destroy a blob that cannot legitimately be removed for 19,200 slots:

```
SOLICIT(h, 0)  →  requests[(h,0)] = []
FORGET(h, 0)   →  deletes requests[(h,0)] AND preimages[h]
```

The genuine request `requests[(h,|p|)] = [x]` survives, still claiming the preimage is available. The index says available; the shelf is empty. Once the blob is gone, auditors lose data they need.

## The proposed solution

Delete `a_preimages[h]` only when `z = |a_preimages[h]|`; otherwise remove just the `(h, z)` request. The `[x]` and `[x,y,w]` branches, result codes, and gas are unchanged.