### PR TITLE
Bandersnatch: bump VRF spec reference and switch to Thin VRF

### DIFF
--- a/biblio.bib
+++ b/biblio.bib
@@ -301,7 +301,7 @@
   author          = {Seyed Hosseini and Davide Galassi},
   year            = {2024},
   url = {https://github.com/davxy/bandersnatch-vrf-spec/blob/main/specification.pdf},
-  note = {Draft 34, Fetched 10th August, 2026}
+  note = {Draft 35, Fetched 21st August, 2026}
 }
 
 @article{ethereum2024sigital,

--- a/biblio.bib
+++ b/biblio.bib
@@ -300,8 +300,8 @@
   title = {Bandersnatch VRF-AD Specification},
   author          = {Seyed Hosseini and Davide Galassi},
   year            = {2024},
-  url = {https://github.com/davxy/bandersnatch-vrfs-spec/blob/main/specification.pdf},
-  note = {Draft 29, Fetched 17th March, 2026}
+  url = {https://github.com/davxy/bandersnatch-vrf-spec/blob/main/specification.pdf},
+  note = {Draft 34, Fetched 10th August, 2026}
 }
 
 @article{ethereum2024sigital,

--- a/text/bandersnatch.tex
+++ b/text/bandersnatch.tex
@@ -2,7 +2,7 @@
 
 The Bandersnatch curve is defined by \cite{cryptoeprint:2021/1152}.
 
-The singly-contextualized Bandersnatch Schnorr-like signatures $\bssignature{k}{c}{m}$ are defined as a formulation under the \emph{IETF} \textsc{vrf} template specified by \cite{hosseini2024bandersnatch} (as IETF VRF) and further detailed by \cite{rfc9381}.
+The singly-contextualized Bandersnatch Schnorr-like signatures $\bssignature{k}{c}{m}$ are defined as a formulation under the \emph{Thin} \textsc{vrf} template specified by \cite{hosseini2024bandersnatch}, itself loosely inspired by the \textsc{ietf} \textsc{ecvrf} of \cite{rfc9381}.
 
 \begin{align}
   \bssignature{k \in \bskey}{c \in \blob}{m \in \blob} \subset \blob[96] &\equiv \set{\build{x}{x \in \blob[96], \text{verify}(k, c, m, x) = \top }}  \\


### PR DESCRIPTION
Bumps the Bandersnatch VRF spec reference from draft 29 to draft 35.

Draft 35 drops plain "IETF VRF" in favour of two more advanced schemes, Thin-VRF and Tiny-VRF, which share a delinearized DLEQ core and a transcript-based Fiat–Shamir transform.

Key differences between Thin and Tiny:
* Tiny VRF has a 48-byte signature, compared to 64 bytes for Thin VRF.
* Thin VRF supports batching (Tiny not). 

For the sake of JAM I opted for Thin.

Note that this change is wire-incompatible with draft 29.
