### PR TITLE
Serialization: Require rejection of non-minimal natural encodings

### DIFF
--- a/text/serialization.tex
+++ b/text/serialization.tex
@@ -2,7 +2,7 @@
 
 \subsection{Common Terms}
 
-Our codec function $\mathcal{E}$ is used to serialize some term into a sequence of octets. We define the deserialization function $\fndecode$ as the inverse of $\mathcal{E}$ and able to decode some sequence into the original value. The codec is designed such that exactly one value is encoded into any given sequence of octets, and in cases where this is not desirable then we use special codec functions.
+Our codec function $\mathcal{E}$ is used to serialize some term into a sequence of octets. We define the deserialization function $\fndecode$ as the inverse of $\mathcal{E}$ and able to decode some sequence into the original value. The codec is designed such that exactly one value is encoded into any given sequence of octets, and in cases where this is not desirable then we use special codec functions. Since $\mathcal{E}$ is injective, $\fndecode$ is defined only over its image: an octet sequence which is not the encoding of any value (\eg one containing a non-minimal natural number encoding) is invalid and must be rejected when decoding.
 
 \subsubsection{Trivial Encodings}
 We define the serialization of $\none$ as the empty sequence:


### PR DESCRIPTION
The natural number serialization is defined only in the encoding direction. The byte format still admits sequences that no value encodes to — e.g. `0x80 0x05`, which a structural decoder reads as `5` — and the paper never states what a decoder must do with them. Accepting them is a defensible reading; so is rejecting them.

Two implementations taking different sides of that choice will disagree on block validity, forking the chain with both faithfully implementing the paper. Lenient decoding also gives one object multiple byte representations — and thus multiple hashes — breaking anything that identifies objects by hash. Widely used varint codecs are genuinely split on this behavior, so implementer defaults cannot be relied upon.

This addition pins down the conformant behavior in one sentence, giving conformance vectors and audits an explicit requirement to anchor to. 