### PR TITLE
Make authqueue dynamically sized

### DIFF
--- a/text/accumulation.tex
+++ b/text/accumulation.tex
@@ -137,7 +137,7 @@ Our formalisms continue by defining $\partialstate$ as a characterization of (\i
   \partialstate \equiv \tuple{\begin{aligned}
     &\isa{\ps¬accounts}{\dictionary{\serviceid}{\serviceaccount}} \,,\;
     \isa{\ps¬stagingset}{\allvalkeys} \,,\;
-    \isa{\ps¬authqueue}{\sequence[\Ccorecount]{\sequence[\Cauthqueuesize]{\hash}}} \,,\;
+    \isa{\ps¬authqueue}{\sequence[\Ccorecount]{\sequence[:\Cauthqueuesize]{\hash}}} \,,\;
     \isa{\ps¬manager}{\serviceid} \,,\\
     &\isa{\ps¬assigners}{\sequence[\Ccorecount]{\serviceid}} \,,\;
     \isa{\ps¬delegator}{\serviceid} \,,\;

--- a/text/authorization.tex
+++ b/text/authorization.tex
@@ -16,14 +16,17 @@ We define the set of authorizers allowable for a particular core $\¬core$ as th
 \begin{equation}
   \label{eq:authstatecomposition}
   \authpool \in \sequence[\Ccorecount]{\sequence[:\Cauthpoolsize]{\hash}}\ , \qquad
-  \authqueue \in \sequence[\Ccorecount]{\sequence[\Cauthqueuesize]{\hash}}
+  \authqueue \in \sequence[\Ccorecount]{\sequence[:\Cauthqueuesize]{\hash}}
 \end{equation}
 
 Note: The portion of state $\authqueue$ may be altered only through an exogenous call made from the accumulate logic of an appropriately privileged service.
 
 The state transition of a block involves placing a new authorization into the pool from the queue:
 \begin{align}
-  &\forall \¬core \in \coreindex : \authpool'\subb{\¬core} \equiv {\overleftarrow{F(\¬core) \append \cyclic{\authqueue'\subb{\¬core}\subb{\H_\¬timeslot}}}}^{\Cauthpoolsize} \\
+  &\forall \¬core \in \coreindex : \authpool'\subb{\¬core} \equiv \begin{cases}
+    {\overleftarrow{F(\¬core)}}^{\Cauthpoolsize} &\when \authqueue'\subb{\¬core} = \sq{} \\
+    {\overleftarrow{F(\¬core) \append \cyclic{\authqueue'\subb{\¬core}\subb{\H_\¬timeslot}}}}^{\Cauthpoolsize} &\otherwise
+  \end{cases} \\
   &F(\¬core) \equiv \begin{cases} \authpool[\¬core] \seqminusl \set{(g_\g¬workreport)_\wr¬authorizer} &\when \exists g \in \xtguarantees : (g_\g¬workreport)_\¬core = \¬core \\ \authpool[\¬core] & \otherwise \end{cases}
 \end{align}
 

--- a/text/definitions.tex
+++ b/text/definitions.tex
@@ -273,7 +273,7 @@ Here, the prime annotation indicates posterior state. Individual components may 
   \item[$\Cmaxextrinsicoffenses = 16$] The maximum number each of culprits or faults which may be included in a single extrinsic. See equation \ref{eq:disputesextrinsics}.
   \item[$\Cauthpoolsize = 8$] The maximum number of items in the authorizations pool. See equation \ref{eq:authstatecomposition}.
   \item[$\Cslotseconds = 6$] The slot period, in seconds. See equation \ref{sec:epochsandslots}.
-  \item[$\Cauthqueuesize = 80$] The number of items in the authorizations queue. See equation \ref{eq:authstatecomposition}.
+  \item[$\Cauthqueuesize = 80$] The maximum number of items in the authorizations queue. See equation \ref{eq:authstatecomposition}.
   \item[$\Crotationperiod = 10$] The rotation period of validator-core assignments, in timeslots. See sections \ref{sec:coresandvalidators} and \ref{sec:workreportguarantees}.
   \item[$\Cminpublicindex = 2^{16}$] The minimum public service index. Services of indices below these may only be created by the Registrar. See equation \ref{eq:newserviceindex}.
   \item[$\Cmaxpackagexts = 128$] The maximum number of extrinsics in a work-package. See equation \ref{eq:limitworkpackagebandwidth}.

--- a/text/merklization.tex
+++ b/text/merklization.tex
@@ -20,7 +20,7 @@ The state serialization is then defined as the dictionary built from the amalgam
 \begin{equation}
   T(\thestate) \equiv \abracegroup{
     &&C(1) &\mapsto \encode{\sq{\build{\var{x}}{x \orderedin \authpool}}} \;, \\
-    &&C(2) &\mapsto \encode{\authqueue} \;, \\
+    &&C(2) &\mapsto \encode{\sq{\build{\var{x}}{x \orderedin \authqueue}}} \;, \\
     &&C(3) &\mapsto \encode{
       \var{\sq{\build{
         \tup{\rh¬headerhash, \rh¬accoutlogsuperpeak, \rh¬stateroot, \encode[4]{\rh¬timeslot}, \var{\rh¬reportedpackagehashes}}

--- a/text/pvm_invocations.tex
+++ b/text/pvm_invocations.tex
@@ -772,13 +772,14 @@ These assume a context $\imXY \in \implications^2$; see equation \ref{eq:implica
   $\Omega_A(\gascounter, \registers, \memory, \imXY)$ \\
   \texttt{assign} = 16} &
   $\begin{aligned}
-    \using \sq{c, o, a} &= \registers\subrange{7}{3} \\
+    \using \sq{c, o, n, a} &= \registers\subrange{7}{4} \\
     \using \mathbf{q} &= \begin{cases}
-      \sq{\build{\memory\subrange{o + 32i}{32}}{i \orderedin \N_\Cauthqueuesize}} &\when \Nrange{o}{32\Cauthqueuesize} \subseteq \readable{\memory} \\
+      \sq{\build{\memory\subrange{o + 32i}{32}}{i \orderedin \N_n}} &\when \Nrange{o}{32n} \subseteq \readable{\memory} \\
       \error &\otherwise
     \end{cases} \\
     \tup{\execst', \registers'_7, (\imX'_\im¬state)_\ps¬authqueue\subb{c}, (\imX'_\im¬state)_\ps¬assigners\subb{c}} &\equiv \begin{cases}
       \tup{\panic, \registers_7, (\imX_\im¬state)_\ps¬authqueue\subb{c}, (\imX_\im¬state)_\ps¬assigners\subb{c}} &\when \mathbf{q} = \error \\
+      \tup{\continue, \mathtt{HUH}, (\imX_\im¬state)_\ps¬authqueue\subb{c}, (\imX_\im¬state)_\ps¬assigners\subb{c}} &\otherwhen n > \Cauthqueuesize \\
       \tup{\continue, \mathtt{CORE}, (\imX_\im¬state)_\ps¬authqueue\subb{c}, (\imX_\im¬state)_\ps¬assigners\subb{c}} &\otherwhen c \ge \Ccorecount \\
       \tup{\continue, \mathtt{HUH}, (\imX_\im¬state)_\ps¬authqueue\subb{c}, (\imX_\im¬state)_\ps¬assigners\subb{c}} &\otherwhen \imX_\im¬id \ne (\imX_\im¬state)_\ps¬assigners\subb{c}\\
       \tup{\continue, \mathtt{WHO}, (\imX_\im¬state)_\ps¬authqueue\subb{c}, (\imX_\im¬state)_\ps¬assigners\subb{c}} &\otherwhen a \not\in \serviceid \\


### PR DESCRIPTION
Instead of requiring authqueue to be statically bound to 80 items, this changes it to accept any number of authorizer hashes up to 80 elements. This is quite useful when a core has `80 % x != 0` authorizer hashes registered. Because before it would have required the designate authority to update the queue in a way that these `X` authorizer hashes are getting the same number of slots. With the changes, JAM natively handles this.