### PR TITLE
PVM: Mask the third register of three-register instructions

### DIFF
--- a/text/pvm.tex
+++ b/text/pvm.tex
@@ -635,7 +635,7 @@ We assume the skip length $\ell$ is well-defined:
   \using r_B &= \min(12, \ffrac{\instructions_{\imath+1}}{16}) \,,\quad&
   \reg_B &\equiv \reg_{r_B} \,,\quad
   \reg'_B \equiv \reg'_{r_B} \\
-  \using r_D &= \min(12, \instructions_{\imath+2}) \,,\quad&
+  \using r_D &= \min(12, (\instructions_{\imath+2}) \bmod 16) \,,\quad&
   \reg_D &\equiv \reg_{r_D} \,,\quad
   \reg'_D \equiv \reg'_{r_D} \\
 \end{aligned}


### PR DESCRIPTION
Trivial consistency fix for decoding the third register of three-register instructions (since all other encoding formats only look at most at 4 bits). This doesn't affect "well formed" programs, and only affects those programs which encode an out-of-bounds register. Technically the modulo here is somewhat redundant since we have the `min` there anyway, but it allows for a slightly more efficient implementation (i.e. you decode by reading in big chunks only once per instruction, possibly more than you need to decode, and then decode by purely using bitshifts + bitmasks, which makes the extra modulo "free").